### PR TITLE
#DP-81 Fix: Login redirection

### DIFF
--- a/src/pages/Organization/AdminLogin.tsx
+++ b/src/pages/Organization/AdminLogin.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { FaGoogle, FaRegEnvelope, FaRegEye } from 'react-icons/fa';
 import { FiEyeOff } from 'react-icons/fi';
 import { MdLockOutline } from 'react-icons/md';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { UserContext } from '../../hook/useAuth';
 import Button from '../../components/Buttons';
@@ -23,7 +23,7 @@ function AdminLogin() {
   }: any = useForm();
   const { login } = useContext(UserContext);
   const navigate = useNavigate();
-
+  const { state } = useLocation();
   const onSubmit = (data: any) => {
     const role = data?.email.split('@')[0];
     const validRoles = ['admin', 'trainee', 'coordinator', 'user', 'super'];
@@ -31,7 +31,12 @@ function AdminLogin() {
       return toast.error(`Only these roles are accepted: ${validRoles}`);
     }
     login({ ...data, name: role.toUpperCase(), role });
-    navigate('/dashboard/');
+    if (state) {
+      navigate(`${state}`);
+    } else {
+      navigate('/dashboard/');
+    }
+
     return;
   };
 
@@ -40,6 +45,19 @@ function AdminLogin() {
       <div className="md:rounded-2xl md:shadow-2xl md:flex md:w-2/3 mt-16 md:max-w-4xl sm:max-w-xl sm:rounded-none sm:shadow-none dark:shadow-2xl mb-8">
         <div className="md:w-3/5 md:p-5 sm:w-full sm:p-2 dark:bg-dark-frame-bg  dark:rounded-none">
           <div className="py-10 sm:py-8 ">
+            {state ? (
+              <>
+                <h3 className="text-md font-bold text-gray-400 my-2 dark:text-red-400 ">
+                  Login is required to access
+                </h3>
+                <p className="text-md font-bold  text-gray-400 mb-3 dark:text-dark-text-fill ">
+                  <em>{`${state}`}</em>
+                </p>
+              </>
+            ) : (
+              ''
+            )}
+
             <h2 className="text-2xl font-bold text-primary dark:text-dark-text-fill ">
               {t('Sign in using')}
             </h2>
@@ -56,10 +74,15 @@ function AdminLogin() {
               {t('or use your email account')}
             </p>
             <div className="flex flex-col items-center">
-              <form action="#none" onSubmit={handleSubmit(onSubmit)}>
+              <form
+                action="#none"
+                onSubmit={handleSubmit(onSubmit)}
+                data-testid="loginForm"
+              >
                 <div className="bg-gray-100 w-64 p-2 flex items-center mb-2 dark:bg-dark-bg ">
                   <FaRegEnvelope className="text-gray-400 mr-2" />
                   <input
+                    data-testid="email"
                     type="email"
                     {...register('email', { required: 'Email is required' })}
                     placeholder={t('Email')}
@@ -77,6 +100,7 @@ function AdminLogin() {
                 <div className="bg-gray-100 w-64 p-2 flex items-center rounded mb-2 dark:border-white dark:bg-dark-bg">
                   <MdLockOutline className="text-gray-400 mr-2 " />
                   <input
+                    data-testid="password"
                     type={passwordShown ? 'text' : 'password'}
                     {...register('password', {
                       required: 'Password is required',
@@ -130,10 +154,8 @@ function AdminLogin() {
             </div>
             <div className="md:hidden mt-2 text-xs text-center dark:text-dark-text-fill">
               {t('First time here?')}
-              <Link to="/register-organization" className="mx-1">
-                <a href="#link" className="text-primary">
-                  {t('Register')}
-                </a>
+              <Link to="/register-organization" className="mx-1 text-primary">
+                {t('Register')}
               </Link>
               {t('your organization')}
             </div>
@@ -147,13 +169,11 @@ function AdminLogin() {
           <p className="lg:mb-10 lg:text-center md:text-medium sm:text-center sm:mb-2 sm:text-sm md:text-justify dark:text-dark-text-fill ">
             {t('Sign_in_page_paragraph')}
           </p>
-          <Link to="/register-organization">
-            <a
-              href="#link"
-              className="border-2 border-white rounded-full lg:px-8 lg:py-2 inline-block lg:font-semibold md:font-xl md:mt-[72px] sm:font-medium sm:px-4 sm:py-1 hover:bg-white hover:text-primary dark:hover:bg-dark-bg dark:hover:text-dark-text-fill "
-            >
-              {t('Register')}
-            </a>
+          <Link
+            to="/register-organization"
+            className="border-2 border-white rounded-full lg:px-8 lg:py-2 inline-block lg:font-semibold md:font-xl md:mt-[72px] sm:font-medium sm:px-4 sm:py-1 hover:bg-white hover:text-primary dark:hover:bg-dark-bg dark:hover:text-dark-text-fill "
+          >
+            {t('Register')}
           </Link>
         </div>
       </div>

--- a/src/pages/tests/AdminLogin.test.tsx
+++ b/src/pages/tests/AdminLogin.test.tsx
@@ -1,7 +1,22 @@
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
+import UserProvider from '../../hook/useAuth';
 import AdminLogin from '../Organization/AdminLogin';
+
+const mockedUsedLocation = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockedUsedLocation,
+}));
+
+const mockUseLocationValue = {
+  pathname: '/testroute',
+  search: '',
+  hash: '',
+  state: '/dashboard/trainee',
+};
 
 describe('Admin Login', () => {
   it('Should render', () => {
@@ -13,5 +28,41 @@ describe('Admin Login', () => {
       )
       .toJSON();
     expect(elem).toMatchSnapshot();
+  });
+});
+
+describe('Admin login with error', () => {
+  jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn().mockImplementation(() => mockUseLocationValue),
+  }));
+  it('Should render with login error message', async () => {
+    const { getByTestId, findByText } = render(
+      <MemoryRouter>
+        <UserProvider>
+          <AdminLogin />
+        </UserProvider>
+      </MemoryRouter>,
+    );
+    fireEvent.submit(getByTestId('loginForm'));
+    expect(await findByText('Email is required')).toBeInTheDocument();
+  });
+  it('Should submit the form', async () => {
+    const { getByTestId, findByText } = render(
+      <MemoryRouter>
+        <UserProvider>
+          <AdminLogin />
+        </UserProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.input(getByTestId('email'), {
+      target: { value: 'admin@me.com' },
+    });
+    fireEvent.input(getByTestId('password'), {
+      target: { value: '12345678' },
+    });
+    fireEvent.submit(getByTestId('loginForm'));
+    expect(await findByText('Sign In')).toBeInTheDocument();
   });
 });

--- a/src/pages/tests/__snapshots__/AdminLogin.test.tsx.snap
+++ b/src/pages/tests/__snapshots__/AdminLogin.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`Admin Login Should render 1`] = `
         >
           <form
             action="#none"
+            data-testid="loginForm"
             onSubmit={[Function]}
           >
             <div
@@ -85,6 +86,7 @@ exports[`Admin Login Should render 1`] = `
               </svg>
               <input
                 className="bg-gray-100 outline-none text-sm flex-1 text-gray-400 dark:border-white dark:bg-dark-bg dark:text-white "
+                data-testid="email"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -123,6 +125,7 @@ exports[`Admin Login Should render 1`] = `
               </svg>
               <input
                 className="bg-gray-100 outline-none text-sm flex-1 text-gray-400 dark:border-white dark:bg-dark-bg dark:text-white"
+                data-testid="password"
                 name="password"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -200,16 +203,11 @@ exports[`Admin Login Should render 1`] = `
         >
           First time here?
           <a
-            className="mx-1"
+            className="mx-1 text-primary"
             href="/register-organization"
             onClick={[Function]}
           >
-            <a
-              className="text-primary"
-              href="#link"
-            >
-              Register
-            </a>
+            Register
           </a>
           your organization
         </div>
@@ -232,15 +230,11 @@ exports[`Admin Login Should render 1`] = `
         Sign_in_page_paragraph
       </p>
       <a
+        className="border-2 border-white rounded-full lg:px-8 lg:py-2 inline-block lg:font-semibold md:font-xl md:mt-[72px] sm:font-medium sm:px-4 sm:py-1 hover:bg-white hover:text-primary dark:hover:bg-dark-bg dark:hover:text-dark-text-fill "
         href="/register-organization"
         onClick={[Function]}
       >
-        <a
-          className="border-2 border-white rounded-full lg:px-8 lg:py-2 inline-block lg:font-semibold md:font-xl md:mt-[72px] sm:font-medium sm:px-4 sm:py-1 hover:bg-white hover:text-primary dark:hover:bg-dark-bg dark:hover:text-dark-text-fill "
-          href="#link"
-        >
-          Register
-        </a>
+        Register
       </a>
     </div>
   </div>


### PR DESCRIPTION
### What the PR does
This pull request fix the redirection issue upon success login after an attempt to access protected route. The following tasks has been completed

- [x] The user is redirected to the requested pages
- [x] The user receives a warning when accessing protected route

### Background context
This PR will fix an open issue and boost user experience since they will not have to remember the route requested after a successful login

### How should this be manually tested
When you try to access the protected route ex `/dashboard/trainee` you will receive a warning that you are trying to access a route that requires login. Instead of redirecting to the default `dashboard` you will be redirected to the requested route
To manually test this:
1. Open the site following link: [https://devpulse-review-app-49.herokuapp.com/dashboard/calendar](https://devpulse-review-app-49.herokuapp.com/dashboard/calendar)
2. Do a successful login
3. Check the redirect

### Screenshot if applicable
![image](https://user-images.githubusercontent.com/28519395/182014864-6da230b3-9a37-4df2-8661-a31acf06a38c.png)
