### PR TITLE
#DP-89: (Feat) Homepage translation

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../App';
 import {
@@ -8,10 +8,25 @@ import {
   FaLinkedin,
   FaPlayCircle,
 } from 'react-icons/fa';
+import i18next from 'i18next';
 import LogoFooter from '../assets/logoWhite.svg';
+import getLanguage from '../utils/getLanguage';
 
 function Footer({ styles }: any) {
   const { t } = useTranslation();
+  const lan = getLanguage();
+  const userLang = window.navigator.language;
+  const changeLan = (e: { target: { value: string } }) => {
+    const { value } = e.target;
+    i18next.changeLanguage(value);
+  };
+  const lanRef = useRef<any>();
+
+  useEffect(() => {
+    if (lanRef.current) {
+      lanRef.current.value = lan;
+    }
+  }, []);
   return (
     <div
       className={`w-full bg-primary dark:bg-dark-bg text-gray-300 mt-auto ${styles}`}
@@ -55,13 +70,31 @@ function Footer({ styles }: any) {
               <ul className="lg:flex lg:flex-col ml-[8vh] md:ml-[16vh] lg:ml-28 cursor-pointer">
                 <li className="py-2 text-xs">{t('Terms and conditions')}</li>
                 <li className="py-2 text-xs">{t('Privacy and Policies')}</li>
+                <select
+                  name="language"
+                  defaultValue={userLang}
+                  data-testid="lanChange"
+                  ref={lanRef}
+                  onChange={(e) => {
+                    changeLan(e);
+                  }}
+                  className="bg-dark-bg mt-2 outline rounded-md px-2 py-1 text-white dark:text-dark-text-fill dark:bg-dark-bg "
+                >
+                  <option value="en">English</option>
+                  <option value="kn">Kinyarwanda</option>
+                  <option value="fr">Français</option>
+                </select>
               </ul>
             </div>
           </div>
         </div>
         <div className=" lg:flex">
           <span className="px-4 lg:py-3 cursor-pointer text-lg">
-            © {new Date().getFullYear()} Pulse Technologies
+            ©
+            {' '}
+            {new Date().getFullYear()}
+            {' '}
+            Pulse Technologies
           </span>
         </div>
       </div>

--- a/src/components/tests/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/tests/__snapshots__/Footer.test.tsx.snap
@@ -206,6 +206,29 @@ exports[`<Footer/> Renders Header 1`] = `
             >
               Privacy and Policies
             </li>
+            <select
+              className="bg-dark-bg mt-2 outline rounded-md px-2 py-1 text-white dark:text-dark-text-fill dark:bg-dark-bg "
+              data-testid="lanChange"
+              defaultValue="en-US"
+              name="language"
+              onChange={[Function]}
+            >
+              <option
+                value="en"
+              >
+                English
+              </option>
+              <option
+                value="kn"
+              >
+                Kinyarwanda
+              </option>
+              <option
+                value="fr"
+              >
+                Français
+              </option>
+            </select>
           </ul>
         </div>
       </div>
@@ -216,9 +239,11 @@ exports[`<Footer/> Renders Header 1`] = `
       <span
         className="px-4 lg:py-3 cursor-pointer text-lg"
       >
-        © 
+        ©
+         
         2022
-         Pulse Technologies
+         
+        Pulse Technologies
       </span>
     </div>
   </div>

--- a/src/containers/tests/__snapshots__/MainRoutes.test.tsx.snap
+++ b/src/containers/tests/__snapshots__/MainRoutes.test.tsx.snap
@@ -682,6 +682,29 @@ exports[`Main Routes Should render 1`] = `
                 >
                   Privacy and Policies
                 </li>
+                <select
+                  className="bg-dark-bg mt-2 outline rounded-md px-2 py-1 text-white dark:text-dark-text-fill dark:bg-dark-bg "
+                  data-testid="lanChange"
+                  defaultValue="en-US"
+                  name="language"
+                  onChange={[Function]}
+                >
+                  <option
+                    value="en"
+                  >
+                    English
+                  </option>
+                  <option
+                    value="kn"
+                  >
+                    Kinyarwanda
+                  </option>
+                  <option
+                    value="fr"
+                  >
+                    Français
+                  </option>
+                </select>
               </ul>
             </div>
           </div>
@@ -692,9 +715,11 @@ exports[`Main Routes Should render 1`] = `
           <span
             className="px-4 lg:py-3 cursor-pointer text-lg"
           >
-            © 
+            ©
+             
             2022
-             Pulse Technologies
+             
+            Pulse Technologies
           </span>
         </div>
       </div>
@@ -905,6 +930,29 @@ exports[`Main Routes Should render 1`] = `
               >
                 Privacy and Policies
               </li>
+              <select
+                className="bg-dark-bg mt-2 outline rounded-md px-2 py-1 text-white dark:text-dark-text-fill dark:bg-dark-bg "
+                data-testid="lanChange"
+                defaultValue="en-US"
+                name="language"
+                onChange={[Function]}
+              >
+                <option
+                  value="en"
+                >
+                  English
+                </option>
+                <option
+                  value="kn"
+                >
+                  Kinyarwanda
+                </option>
+                <option
+                  value="fr"
+                >
+                  Français
+                </option>
+              </select>
             </ul>
           </div>
         </div>
@@ -915,9 +963,11 @@ exports[`Main Routes Should render 1`] = `
         <span
           className="px-4 lg:py-3 cursor-pointer text-lg"
         >
-          © 
+          ©
+           
           2022
-           Pulse Technologies
+           
+          Pulse Technologies
         </span>
       </div>
     </div>

--- a/src/tests/__snapshots__/App.test.tsx.snap
+++ b/src/tests/__snapshots__/App.test.tsx.snap
@@ -475,6 +475,29 @@ exports[`App test  Should render app 1`] = `
                 >
                   Privacy and Policies
                 </li>
+                <select
+                  className="bg-dark-bg mt-2 outline rounded-md px-2 py-1 text-white dark:text-dark-text-fill dark:bg-dark-bg "
+                  data-testid="lanChange"
+                  defaultValue="en-US"
+                  name="language"
+                  onChange={[Function]}
+                >
+                  <option
+                    value="en"
+                  >
+                    English
+                  </option>
+                  <option
+                    value="kn"
+                  >
+                    Kinyarwanda
+                  </option>
+                  <option
+                    value="fr"
+                  >
+                    Français
+                  </option>
+                </select>
               </ul>
             </div>
           </div>
@@ -485,9 +508,11 @@ exports[`App test  Should render app 1`] = `
           <span
             className="px-4 lg:py-3 cursor-pointer text-lg"
           >
-            © 
+            ©
+             
             2022
-             Pulse Technologies
+             
+            Pulse Technologies
           </span>
         </div>
       </div>

--- a/src/tests/__snapshots__/Siderbar.test.tsx.snap
+++ b/src/tests/__snapshots__/Siderbar.test.tsx.snap
@@ -472,6 +472,29 @@ exports[`<Home /> Renders Home 1`] = `
               >
                 Privacy and Policies
               </li>
+              <select
+                className="bg-dark-bg mt-2 outline rounded-md px-2 py-1 text-white dark:text-dark-text-fill dark:bg-dark-bg "
+                data-testid="lanChange"
+                defaultValue="en-US"
+                name="language"
+                onChange={[Function]}
+              >
+                <option
+                  value="en"
+                >
+                  English
+                </option>
+                <option
+                  value="kn"
+                >
+                  Kinyarwanda
+                </option>
+                <option
+                  value="fr"
+                >
+                  Français
+                </option>
+              </select>
             </ul>
           </div>
         </div>
@@ -482,9 +505,11 @@ exports[`<Home /> Renders Home 1`] = `
         <span
           className="px-4 lg:py-3 cursor-pointer text-lg"
         >
-          © 
+          ©
+           
           2022
-           Pulse Technologies
+           
+          Pulse Technologies
         </span>
       </div>
     </div>


### PR DESCRIPTION
### What the PR does:
This PR add the ability to change the language directly from the homepage. This will fix an issue of requiring a user that they login before being able to change the language.

### Tasks completed

- [x] Adds the ability to switch language
- [x] The language switch shows active language
- [x] Closes 44

### How should this be manually tested
This feature can easily be tested by changing the language from the footer of the page and examining the changes in the UI

### Screenshots
Not applicable