### PR TITLE
#DP-96 Fix: Unnecessarily message to a restricted page

### DIFF
--- a/src/pages/Organization/AdminLogin.tsx
+++ b/src/pages/Organization/AdminLogin.tsx
@@ -45,19 +45,6 @@ function AdminLogin() {
       <div className="md:rounded-2xl md:shadow-2xl md:flex md:w-2/3 mt-20 md:max-w-4xl sm:max-w-xl sm:rounded-none sm:shadow-none dark:shadow-2xl mb-8">
         <div className="md:w-3/5 md:p-5 sm:w-full sm:p-2 dark:bg-dark-frame-bg  dark:rounded-none">
           <div className="py-10 sm:py-8 ">
-            {state ? (
-              <>
-                <h3 className="text-md font-bold text-gray-400 my-2 dark:text-red-400 ">
-                  Login is required to access
-                </h3>
-                <p className="text-md font-bold  text-gray-400 mb-3 dark:text-dark-text-fill ">
-                  <em>{`${state}`}</em>
-                </p>
-              </>
-            ) : (
-              ''
-            )}
-
             <h2 className="text-2xl font-bold text-primary dark:text-dark-text-fill ">
               {t('Sign in using')}
             </h2>


### PR DESCRIPTION
# PR Description
This PR is about deleting a message that was being displayed when a user tries to access a restricted page without signing in and the URI that a user was trying to access.
# Description of tasks that were expected to be completed
Redirect a user to a login page without an unnecessarily restricted message like **Login is required to access "URI" name**

- [x] Remove unnecessarily message that says Sign in is required to access URl name

# How has this been tested?
```
git clone https://github.com/atlp-rwanda/atlp-pulse-fn.git 
git checkout fix-unnecessary-restricted-msg-dp-96
npm install
npm run dev
```
Try to access one of the restricted pages like the dashboard 

# Number of Commits
**1 commit**
# Screenshots (If appropriate)
![Fix](https://user-images.githubusercontent.com/50054090/186634671-d8dc31e7-af26-4eb8-9722-f8868edcd0de.png)