### PR TITLE
DP-100 Fix: Settings toggle in light mode

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -12,7 +12,6 @@ function Settings() {
   const { t } = useTranslation();
   const lanRef = useRef<any>();
   const lan = getLanguage();
-  const theme = window.localStorage.getItem('color-theme');
   const [colorTheme, setTheme] = useDarkMode();
   const [emailEnabled, setEmailEnabled] = useState(false);
   const [pushEnabled, setPushEnabled] = useState(false);
@@ -33,6 +32,7 @@ function Settings() {
       lanRef.current.value = lan;
     }
   }, []);
+
   return (
     <div className="flex flex-col grow bg-light-bg dark:bg-dark-frame-bg">
       <div className="flex flex-row justify-center pt-[12vh]">
@@ -69,7 +69,7 @@ function Settings() {
                 </p>
               </div>
               <select
-                defaultValue={theme!}
+                defaultValue="dark"
                 data-testid="themeChange"
                 onChange={(e) => handleThemeChange(e)}
                 className="ml-auto bg-white border px-[2vh] h-8 rounded-md text-xs md:text-sm text-gray-600 dark:text-dark-text-fill dark:bg-dark-bg outline-none"
@@ -110,15 +110,16 @@ function Settings() {
               </div>
               <Switch
                 checked={emailEnabled}
+                data-testid="emailChange"
                 onChange={setEmailEnabled}
-                className="ml-auto border relative inline-flex h-6 w-12 items-center rounded-full"
+                className={`ml-auto border ${emailEnabled ? 'dark:border-primary' : ''} relative inline-flex h-6 w-12 items-center rounded-full`}
               >
                 <span
                   className={`${
                     emailEnabled
-                      ? 'bg-primary translate-x-6'
+                      ? 'bg-primary   translate-x-6'
                       : 'bg-gray-300 translate-x-1'
-                  } inline-block h-4 w-4 transform rounded-full bg-white`}
+                  } inline-block h-4 w-4 transform rounded-full`}
                 />
               </Switch>
             </li>
@@ -133,15 +134,16 @@ function Settings() {
               </div>
               <Switch
                 checked={pushEnabled}
+                data-testid="pushChange"
                 onChange={setPushEnabled}
-                className="ml-auto border relative inline-flex h-6 w-12 items-center rounded-full"
+                className={` ml-auto border ${pushEnabled ? 'dark:border-primary' : ''} relative inline-flex h-6 w-12 items-center rounded-full`}
               >
                 <span
                   className={`${
                     pushEnabled
-                      ? 'bg-primary translate-x-6'
+                      ? 'bg-primary   translate-x-6'
                       : 'bg-gray-300 translate-x-1'
-                  } inline-block h-4 w-4 transform rounded-full bg-white`}
+                  } inline-block h-4 w-4 transform rounded-full `}
                 />
               </Switch>
             </li>

--- a/src/pages/tests/Settings.test.tsx
+++ b/src/pages/tests/Settings.test.tsx
@@ -16,13 +16,22 @@ describe('Settings page tests', () => {
       </BrowserRouter>,
     );
     let theme = getByTestId('themeChange');
-    expect(theme).toHaveValue('light');
+    expect(theme).toHaveValue('dark');
 
     fireEvent.change(theme, { target: { value: 'dark' } });
     expect(theme).toHaveValue('dark');
 
     fireEvent.change(theme, { target: { value: 'light' } });
     expect(theme).toHaveValue('light');
+
+    let push = getByTestId('pushChange');
+    fireEvent.click(push);
+    expect(push).toBeChecked();
+
+    let email = getByTestId('emailChange');
+    fireEvent.click(email);
+    expect(email).toBeChecked();
+
   });
   it('changes value after selecting another theme', () => {
     const elem = renderer

--- a/src/pages/tests/__snapshots__/Settings.test.tsx.snap
+++ b/src/pages/tests/__snapshots__/Settings.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Settings page tests changes value after selecting another theme 1`] = `
           <select
             className="ml-auto bg-white border px-[2vh] h-8 rounded-md text-xs md:text-sm text-gray-600 dark:text-dark-text-fill dark:bg-dark-bg outline-none"
             data-testid="themeChange"
-            defaultValue="light"
+            defaultValue="dark"
             onChange={[Function]}
           >
             <option
@@ -142,7 +142,8 @@ exports[`Settings page tests changes value after selecting another theme 1`] = `
           </div>
           <button
             aria-checked={false}
-            className="ml-auto border relative inline-flex h-6 w-12 items-center rounded-full"
+            className="ml-auto border  relative inline-flex h-6 w-12 items-center rounded-full"
+            data-testid="emailChange"
             id="headlessui-switch-:r0:"
             onClick={[Function]}
             onKeyPress={[Function]}
@@ -152,7 +153,7 @@ exports[`Settings page tests changes value after selecting another theme 1`] = `
             type="button"
           >
             <span
-              className="bg-gray-300 translate-x-1 inline-block h-4 w-4 transform rounded-full bg-white"
+              className="bg-gray-300 translate-x-1 inline-block h-4 w-4 transform rounded-full"
             />
           </button>
         </li>
@@ -175,7 +176,8 @@ exports[`Settings page tests changes value after selecting another theme 1`] = `
           </div>
           <button
             aria-checked={false}
-            className="ml-auto border relative inline-flex h-6 w-12 items-center rounded-full"
+            className=" ml-auto border  relative inline-flex h-6 w-12 items-center rounded-full"
+            data-testid="pushChange"
             id="headlessui-switch-:r1:"
             onClick={[Function]}
             onKeyPress={[Function]}
@@ -185,7 +187,7 @@ exports[`Settings page tests changes value after selecting another theme 1`] = `
             type="button"
           >
             <span
-              className="bg-gray-300 translate-x-1 inline-block h-4 w-4 transform rounded-full bg-white"
+              className="bg-gray-300 translate-x-1 inline-block h-4 w-4 transform rounded-full "
             />
           </button>
         </li>


### PR DESCRIPTION
# PR Description
 #72 Settings toggle in light mode
# Description of tasks that were expected to be completed
   -  Make email and push notifications toggle visible in light mode
   - Make dark mode the default selected option
# How has this been tested?
- Navigate to the review app and sign in.
-  Go to setting and inspect whether dark mode is selected by default
-  Check whether push and email notifications toggles are visible in light mode

# Screenshots (If appropriate)
<img width="1439" alt="Screen Shot 2022-08-30 at 09 02 02" src="https://user-images.githubusercontent.com/38954786/187371436-9909c84f-912c-4327-b3f5-ac29aa812207.png">

