### PR TITLE
#DP-108 Fix URI naming

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -18,9 +18,9 @@ function MainRoutes() {
       <Router>
         <Header />
         <Routes>
-          <Route path="/register-organization" element={<OrgRegister />} />
+          <Route path="signup/org" element={<OrgRegister />} />
           <Route
-            path="/org-login"
+            path="/login/org"
             element={(
               <ProtectedRoutes>
                 <Orglogin />
@@ -31,7 +31,7 @@ function MainRoutes() {
           <Route path="/pricing-form" element={<Pay />} />
           <Route path="/pricing-form" element={<Pay />} />
           <Route
-            path="/login-admin"
+            path="/login"
             element={(
               <ProtectedRoutes>
                 <AdminLogin />
@@ -39,8 +39,8 @@ function MainRoutes() {
             )}
           />
           <Route path="/" element={<Perfomancetraineetable />} />
-          <Route path="/register-organization" element={<OrgRegister />} />
-          <Route path="/org-login" element={<Orglogin />} />
+          <Route path="/signup/org" element={<OrgRegister />} />
+          <Route path="/login/org" element={<Orglogin />} />
           <Route path="*" element={<Error />} />
           <Route path="/noredirect" element={<Noredirect />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,7 +97,7 @@ const Header = forwardRef(({ open, setOpen, ...props }: any, ref: any) => {
               <SunIcon className="w-8 text-dark-text-fill" />
             )}
           </button>
-          <Link to={user?.auth ? '/dashboard' : '/org-login'}>
+          <Link to={user?.auth ? '/dashboard' : '/login/org'}>
             <Button variant="primary" size="lg">
               {' '}
               {!user?.auth ? t('Sign In') : t('Dashboard')}
@@ -116,7 +116,7 @@ const Header = forwardRef(({ open, setOpen, ...props }: any, ref: any) => {
               {' '}
             </Button>
           ) : (
-            <Link to="/register-organization">
+            <Link to="/signup/org">
               <Button variant="transparentbtn" size="lg" style="mr-8">
                 {' '}
                 {t('Register an organization')}
@@ -165,7 +165,7 @@ const Header = forwardRef(({ open, setOpen, ...props }: any, ref: any) => {
 
         <li className="p-2 w-full dark:text-dark-text-fill mt-6 mb-2 bg-primary text-white rounded-md px-[35%]">
           <Link
-            to={user?.auth ? '/dashboard' : '/org-login'}
+            to={user?.auth ? '/dashboard' : '/login/org'}
             className="w-full"
           >
             {' '}
@@ -184,7 +184,7 @@ const Header = forwardRef(({ open, setOpen, ...props }: any, ref: any) => {
             {' '}
           </Button>
         ) : (
-          <Link to="/register-organization">
+          <Link to="/signup/org">
             <Button variant="transparentbtn" size="lg" style="mr-8">
               {' '}
               {t('Register an organization')}

--- a/src/components/Payment-steps/steps/Complete.tsx
+++ b/src/components/Payment-steps/steps/Complete.tsx
@@ -25,7 +25,7 @@ export default function Final() {
           >
             {t('Back')}
           </Button>
-          <Link to="/register-organization">
+          <Link to="/signup/org">
             <Button variant="primary" size="lg" data-testid="link">
               {t('Continue registration')}
             </Button>

--- a/src/components/tests/__snapshots__/Header.test.tsx.snap
+++ b/src/components/tests/__snapshots__/Header.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Header Tests Should render the header with home 1`] = `
         </svg>
       </button>
       <a
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
         <button
@@ -101,7 +101,7 @@ exports[`Header Tests Should render the header with home 1`] = `
         </button>
       </a>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button
@@ -196,7 +196,7 @@ exports[`Header Tests Should render the header with home 1`] = `
     >
       <a
         className="w-full"
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
          
@@ -204,7 +204,7 @@ exports[`Header Tests Should render the header with home 1`] = `
       </a>
     </li>
     <a
-      href="/register-organization"
+      href="/signup/org"
       onClick={[Function]}
     >
       <button
@@ -307,7 +307,7 @@ exports[`Header Tests Should render the header with no active 1`] = `
         </svg>
       </button>
       <a
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
         <button
@@ -321,7 +321,7 @@ exports[`Header Tests Should render the header with no active 1`] = `
         </button>
       </a>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button
@@ -416,7 +416,7 @@ exports[`Header Tests Should render the header with no active 1`] = `
     >
       <a
         className="w-full"
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
          
@@ -424,7 +424,7 @@ exports[`Header Tests Should render the header with no active 1`] = `
       </a>
     </li>
     <a
-      href="/register-organization"
+      href="/signup/org"
       onClick={[Function]}
     >
       <button
@@ -740,7 +740,7 @@ exports[`Header Tests Should render the header with no active 3`] = `
         </svg>
       </button>
       <a
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
         <button
@@ -754,7 +754,7 @@ exports[`Header Tests Should render the header with no active 3`] = `
         </button>
       </a>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button
@@ -849,7 +849,7 @@ exports[`Header Tests Should render the header with no active 3`] = `
     >
       <a
         className="w-full"
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
          
@@ -857,7 +857,7 @@ exports[`Header Tests Should render the header with no active 3`] = `
       </a>
     </li>
     <a
-      href="/register-organization"
+      href="/signup/org"
       onClick={[Function]}
     >
       <button
@@ -961,7 +961,7 @@ exports[`Header Tests Should render the header with pricing active 1`] = `
         </svg>
       </button>
       <a
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
         <button
@@ -975,7 +975,7 @@ exports[`Header Tests Should render the header with pricing active 1`] = `
         </button>
       </a>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button
@@ -1070,7 +1070,7 @@ exports[`Header Tests Should render the header with pricing active 1`] = `
     >
       <a
         className="w-full"
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
          
@@ -1078,7 +1078,7 @@ exports[`Header Tests Should render the header with pricing active 1`] = `
       </a>
     </li>
     <a
-      href="/register-organization"
+      href="/signup/org"
       onClick={[Function]}
     >
       <button
@@ -1182,7 +1182,7 @@ exports[`Header Tests Should render the header with product active 1`] = `
         </svg>
       </button>
       <a
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
         <button
@@ -1196,7 +1196,7 @@ exports[`Header Tests Should render the header with product active 1`] = `
         </button>
       </a>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button
@@ -1291,7 +1291,7 @@ exports[`Header Tests Should render the header with product active 1`] = `
     >
       <a
         className="w-full"
-        href="/org-login"
+        href="/login/org"
         onClick={[Function]}
       >
          
@@ -1299,7 +1299,7 @@ exports[`Header Tests Should render the header with product active 1`] = `
       </a>
     </li>
     <a
-      href="/register-organization"
+      href="/signup/org"
       onClick={[Function]}
     >
       <button

--- a/src/containers/Routes.tsx
+++ b/src/containers/Routes.tsx
@@ -27,9 +27,9 @@ function MainRoutes() {
           <Route path="/" element={<Home />} />
           <Route path="/register" element={<UserRegister />} />
           <Route path="/register-successful" element={<Message />} />
-          <Route path="/register-organization" element={<OrgRegister />} />
+          <Route path="/signup/org" element={<OrgRegister />} />
           <Route
-            path="/org-login"
+            path="/login/org"
             element={
               <ProtectedRoutes>
                 <Orglogin />
@@ -37,7 +37,7 @@ function MainRoutes() {
             }
           />
           <Route
-            path="/login-admin"
+            path="/login"
             element={
               <ProtectedRoutes>
                 <Adminlogin />

--- a/src/containers/tests/__snapshots__/MainRoutes.test.tsx.snap
+++ b/src/containers/tests/__snapshots__/MainRoutes.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`Main Routes Should render 1`] = `
           </svg>
         </button>
         <a
-          href="/org-login"
+          href="/login/org"
           onClick={[Function]}
         >
           <button
@@ -104,7 +104,7 @@ exports[`Main Routes Should render 1`] = `
           </button>
         </a>
         <a
-          href="/register-organization"
+          href="/signup/org"
           onClick={[Function]}
         >
           <button
@@ -199,7 +199,7 @@ exports[`Main Routes Should render 1`] = `
       >
         <a
           className="w-full"
-          href="/org-login"
+          href="/login/org"
           onClick={[Function]}
         >
            
@@ -207,7 +207,7 @@ exports[`Main Routes Should render 1`] = `
         </a>
       </li>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button
@@ -311,7 +311,7 @@ exports[`Main Routes Should render 1`] = `
             </svg>
           </button>
           <a
-            href="/org-login"
+            href="/login/org"
             onClick={[Function]}
           >
             <button
@@ -325,7 +325,7 @@ exports[`Main Routes Should render 1`] = `
             </button>
           </a>
           <a
-            href="/register-organization"
+            href="/signup/org"
             onClick={[Function]}
           >
             <button
@@ -420,7 +420,7 @@ exports[`Main Routes Should render 1`] = `
         >
           <a
             className="w-full"
-            href="/org-login"
+            href="/login/org"
             onClick={[Function]}
           >
              
@@ -428,7 +428,7 @@ exports[`Main Routes Should render 1`] = `
           </a>
         </li>
         <a
-          href="/register-organization"
+          href="/signup/org"
           onClick={[Function]}
         >
           <button

--- a/src/pages/Organization/AdminLogin.tsx
+++ b/src/pages/Organization/AdminLogin.tsx
@@ -198,7 +198,7 @@ function AdminLogin() {
 
             <div className="my-4 text-sm text-center dark:text-dark-text-fill">
               {t('First time here?')}
-              <Link to="/register-organization" className="mx-1 text-primary">
+              <Link to="/signup/org" className="mx-1 text-primary">
                 {t('Register')}
               </Link>
               {t('your organization')}

--- a/src/pages/Organization/Orglogin.tsx
+++ b/src/pages/Organization/Orglogin.tsx
@@ -28,7 +28,7 @@ function Orglogin() {
       onCompleted({ loginOrg }) {
         localStorage.setItem('orgToken', loginOrg.token);
         toast.success('Welcome! Sign in to Continue');
-        navigate('/login-admin/');
+        navigate('/login');
       },
       onError() {
         setError('name', {
@@ -64,7 +64,7 @@ function Orglogin() {
             )}
           </div>
           <div>
-            <Link to="/login-admin">
+            <Link to="/login">
               <Button
                 onClick={handleSubmit(onSubmit)}
                 variant="primary"
@@ -95,7 +95,7 @@ function Orglogin() {
           </div>
           <div className="w-full text-sm  text-light-text dark:text-dark-text-fill">
             {t('Looking to register an organization instead?')}
-            <Link to="/register-organization">
+            <Link to="/signup/org">
               <a href="#link" className="text-primary">
                 {t('Register a new organization')}
               </a>

--- a/src/pages/Organization/UserRegister.tsx
+++ b/src/pages/Organization/UserRegister.tsx
@@ -183,7 +183,7 @@ function Signup() {
             </div>
             <div className="md:hidden mt-2 text-xs text-center dark:text-dark-text-fill">
               {t('First time here?')}
-              <Link to="/register-organization" className="mx-1 text-primary">
+              <Link to="/signup/org" className="mx-1 text-primary">
                 {t('Register')}
               </Link>
               {t('your organization')}

--- a/src/pages/tests/__snapshots__/AdminLogin.test.tsx.snap
+++ b/src/pages/tests/__snapshots__/AdminLogin.test.tsx.snap
@@ -228,7 +228,7 @@ Array [
           First time here?
           <a
             className="mx-1 text-primary"
-            href="/register-organization"
+            href="/signup/org"
             onClick={[Function]}
           >
             Register

--- a/src/pages/tests/__snapshots__/OrgLogin.test.tsx.snap
+++ b/src/pages/tests/__snapshots__/OrgLogin.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Organization Login Should render 1`] = `
       />
       <div>
         <a
-          href="/login-admin"
+          href="/login"
           onClick={[Function]}
         >
           <button
@@ -84,7 +84,7 @@ exports[`Organization Login Should render 1`] = `
       >
         Looking to register an organization instead?
         <a
-          href="/register-organization"
+          href="/signup/org"
           onClick={[Function]}
         >
           <a

--- a/src/tests/__snapshots__/Siderbar.test.tsx.snap
+++ b/src/tests/__snapshots__/Siderbar.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`<Home /> Renders Home 1`] = `
           </svg>
         </button>
         <a
-          href="/org-login"
+          href="/login/org"
           onClick={[Function]}
         >
           <button
@@ -104,7 +104,7 @@ exports[`<Home /> Renders Home 1`] = `
           </button>
         </a>
         <a
-          href="/register-organization"
+          href="/signup/org"
           onClick={[Function]}
         >
           <button
@@ -199,7 +199,7 @@ exports[`<Home /> Renders Home 1`] = `
       >
         <a
           className="w-full"
-          href="/org-login"
+          href="/login/org"
           onClick={[Function]}
         >
            
@@ -207,7 +207,7 @@ exports[`<Home /> Renders Home 1`] = `
         </a>
       </li>
       <a
-        href="/register-organization"
+        href="/signup/org"
         onClick={[Function]}
       >
         <button


### PR DESCRIPTION
### PR description 
_Fixing URI naming_
### What this PR does
- Fix login URI name
- Fix organization login URI names
- Remove URIs that are no longer in use
### How can it be tested
Go to the app, and navigate to sognin, the organization login should now be `/organization-login`, and the the login uri should now be `/login`.
### Background context
Successfully merging this PR will introduce new names in the links that are more realistic and easier to understand by any user
### Relevant trello ID
[#DP-108](https://trello.com/c/EQl3uwYN/108-fix-login-uri)
### Screenshot
_N/A_
### Checks completed
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My test coverage meet the set test coverage threshold
- [x] There are no conflicts with the base branch