### PR TITLE
implement the help-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
         "webpack-dev-server": "^4.9.3"
       },
       "engines": {
-        "node": "16.x",
+        "node": "18.x",
         "npm": "8.x"
       }
     },

--- a/src/Mutations/help.mutation.tsx
+++ b/src/Mutations/help.mutation.tsx
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+const CREATE_TICKET = gql`
+  mutation CreateTicket($subject: String!, $message: String!) {
+    createTicket(subject: $subject, message: $message) {
+      responseMsg
+    }
+  }
+`;
+export default CREATE_TICKET;

--- a/src/Skeletons/CustomSkeleton.tsx
+++ b/src/Skeletons/CustomSkeleton.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './customSkeleton.css';
+
+function CustomSkeleton() {
+  return <div className="skeleton" />;
+}
+
+export default CustomSkeleton;

--- a/src/Skeletons/customSkeleton.css
+++ b/src/Skeletons/customSkeleton.css
@@ -1,0 +1,29 @@
+.skeleton {
+  animation: skeleton-loading 3s linear infinite alternate;
+  height: 300px;
+  width: 100%;
+}
+
+.skeleton-text {
+  width: 100%;
+  height: 0.7rem;
+  margin-bottom: 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.skeleton-text__body {
+  width: 75%;
+}
+
+.skeleton-footer {
+  width: 30%;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-color: hsla(201, 11%, 65%, 0.76);
+  }
+  100% {
+    background-color: hsl(0, 0%, 83%);
+  }
+}

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -122,9 +122,15 @@ function Notification({
                     className="flex flex-col w-full gap-[5px] cursor-pointer"
                     onClick={() => {
                       markRead(notification.id);
-                      user.role === 'trainee'
-                        ? navigate('/dashboard/performance')
-                        : navigate('/dashboard/ratings');
+
+                      if (user.role === 'superAdmin') {
+                        navigate('/dashboard/tickets');
+                      } else if (user.role === 'trainee') {
+                        navigate('/dashboard/performance');
+                      } else {
+                        navigate('/dashboard/ratings');
+                      }
+
                       handleShowNotification();
                     }}
                     data-testid={index === 0 && 'read'}
@@ -148,7 +154,7 @@ function Notification({
                           : 'border-border-dark dark:border-white border-[1px]'
                       }  mt-[7px] mb-[10px]`}
                     />
-                    
+
                     <XIcon
                       className="border-border-dark dark:fill-white h-[20px] w-[20px] cursor-pointer"
                       onClick={() => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,7 +17,8 @@ import {
   TemplateIcon,
   RefreshIcon,
   UserGroupIcon,
-  MoonIcon
+  MoonIcon,
+  MailIcon,
 } from '@heroicons/react/solid';
 import {
   AcademicCapIcon,
@@ -53,7 +54,16 @@ function Sidebar({ style, toggle }: { style: string; toggle: () => void }) {
             <HomeIcon className="w-5 mr-2 " />
           </SideNavLink>
 
-          <SideNavLink onClick={toggle} name="Admins" data-testid="keppi" to="/dashboard/admins">
+          <SideNavLink onClick={toggle} name="Tickets" to="/dashboard/tickets">
+            <MailIcon className="w-5 mr-2 " />
+          </SideNavLink>
+
+          <SideNavLink
+            onClick={toggle}
+            name="Admins"
+            data-testid="keppi"
+            to="/dashboard/admins"
+          >
             <UsersIcon className="w-5 mr-2 " />
           </SideNavLink>
           <SideNavLink onClick={toggle} name="Domains" to="/dashboard/domains">
@@ -174,9 +184,14 @@ function Sidebar({ style, toggle }: { style: string; toggle: () => void }) {
         <SideNavLink onClick={toggle} name="Docs" to="/dashboard/docs">
           <FolderIcon className="w-5 mr-2 " />
         </SideNavLink>
-        <SideNavLink onClick={toggle} name="Help" to="/dashboard/support">
-          <SupportIcon className="w-5 mr-2 " />
-        </SideNavLink>
+
+        <CheckRole
+          roles={['trainee', 'admin', 'coordinator', 'manager', 'user']}
+        >
+          <SideNavLink onClick={toggle} name="Help" to="/dashboard/support">
+            <SupportIcon className="w-5 mr-2 " />
+          </SideNavLink>
+        </CheckRole>
         {/* Add icons */}
         <div className="flex flex-row ml-10 mt-auto list-none">
           <li className="px-2">

--- a/src/containers/DashRoutes.tsx
+++ b/src/containers/DashRoutes.tsx
@@ -26,6 +26,7 @@ const AdminCohorts = React.lazy(() => import('./admin-dashBoard/Cohorts'));
 const AdminPrograms = React.lazy(() => import('./admin-dashBoard/Programs'));
 const AdminSession = React.lazy(() => import('./admin-dashBoard/Sessions'));
 const AdminPhases = React.lazy(() => import('./admin-dashBoard/Phases'));
+
 const AdminManageRoles = React.lazy(
   () => import('./admin-dashBoard/ManagerRoles'),
 );
@@ -54,6 +55,8 @@ const GradingSystem = React.lazy(() => import('../pages/GradingSystem'));
 const Profile = React.lazy(() => import('../pages/Profile'));
 const EditProfile = React.lazy(() => import('../pages/ProfileEdit'));
 const Organizations = React.lazy(() => import('../components/Organizations'));
+const HelpPage = React.lazy(() => import('../pages/HelpPage'));
+const Tickets = React.lazy(() => import('../pages/Tickets'));
 import Skeleton from '../components/Skeleton';
 import Square from '../Skeletons/Square';
 
@@ -98,6 +101,8 @@ function DashRoutes() {
             <Route path="/calendar" element={<Calendar />} />
             <Route path="/organizations" element={<Organizations />} />
             <Route path="/coordinators" element={<CoordinatorsPage />} />
+            <Route path="/support" element={<HelpPage />} />
+            <Route path="/tickets" element={<Tickets />} />
           </Routes>
         </Suspense>
       </div>

--- a/src/pages/HelpPage.tsx
+++ b/src/pages/HelpPage.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+import { useMutation, gql } from '@apollo/client';
+import Button from '../components/Buttons';
+import ButtonLoading from '../components/ButtonLoading';
+import CREATE_TICKET from '../Mutations/help.mutation';
+import useDocumentTitle from '../hook/useDocumentTitle';
+
+function Help() {
+  const { t } = useTranslation();
+  useDocumentTitle('Support');
+  const [msg, setMsg] = useState({
+    subject: '',
+    message: '',
+  });
+  const [createTicket, { data, loading, error }] = useMutation(CREATE_TICKET);
+
+  if (error) {
+    toast.success(error.message);
+  }
+
+  const handleSubmit = async (e: any) => {
+    e.preventDefault();
+    const res = await createTicket({
+      variables: { subject: msg.subject, message: msg.message },
+
+      onCompleted() {
+        setMsg({
+          subject: '',
+          message: '',
+        });
+        toast.success(
+          t(`Message successfully received! We will get back to you shortly.`),
+        );
+      },
+      onError(error) {
+        /* istanbul ignore next */
+        toast.error(t(`${error.message}`));
+      },
+    });
+  };
+
+  function handleOnChange(e: any) {
+    setMsg({ ...msg, [e.target.name]: e.target.value });
+  }
+
+  return (
+    <div className="flex flex-col grow bg-light-bg dark:bg-dark-frame-bg">
+      <div className="flex flex-row justify-center pt-[12vh]">
+        <div className="rounded-lg sm:w-[90%] md:w-[70%] lg:w-[50%] lg:ml-[38vh] mt-5 lg:mr-[2vh] lg:mb-10 p-6 bg-white dark:bg-dark-bg">
+          <h2 className="text-4xl font-bold dark:text:white mb-10">
+            {t('Support')}
+          </h2>
+          <form action="#none" onSubmit={handleSubmit} data-testid="loginForm">
+            <div className="relative mb-6">
+              <label htmlFor="exampleInput7">{t('Subject')}</label>
+              <input
+                type="text"
+                name="subject"
+                value={msg.subject}
+                placeholder={t('Subject')}
+                onChange={handleOnChange}
+                className="dark:bg-dark-bg"
+                style={{
+                  width: '100%',
+                  padding: '12px 20px',
+                  borderRadius: '4px',
+                  border: '1px solid #ccc',
+                  fontSize: '16px',
+                  resize: 'none',
+                }}
+                required
+              />
+            </div>
+
+            <div className="relative mb-6">
+              <label htmlFor="exampleFormControlTextarea13">
+                {t('Message')}
+              </label>
+              <textarea
+                rows={3}
+                placeholder={t('Message')}
+                name="message"
+                value={msg.message}
+                onChange={handleOnChange}
+                style={{
+                  width: '100%',
+                  height: '150px',
+                  padding: '12px 20px',
+                  borderRadius: '4px',
+                  border: '1px solid #ccc',
+                  fontSize: '16px',
+                  resize: 'none',
+                }}
+                className="dark:bg-dark-bg"
+                required
+              />
+            </div>
+
+            {loading ? (
+              <ButtonLoading style="w-full rounded-full inline-block" />
+            ) : (
+              <Button
+                type="submit"
+                variant="primary"
+                data-testid="loginForm"
+                size="lg"
+                style="w-full ml-0 hover:bg-cyan-700 text-sm"
+              >
+                {' '}
+                {t('Send')}
+              </Button>
+            )}
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Help;

--- a/src/pages/Tickets.tsx
+++ b/src/pages/Tickets.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@apollo/client';
+import CustomSkeleton from '../Skeletons/CustomSkeleton';
+import Button from '../components/Buttons';
+import GET_TICKETS from '../queries/tickets.queries';
+import timePassedCalculator from '../utils/timePassedFormating';
+import useDocumentTitle from '../hook/useDocumentTitle';
+
+function Tickets() {
+  const { t } = useTranslation();
+  useDocumentTitle('Tickets');
+  const [page, setPage] = useState(0);
+  const { loading, error, data } = useQuery(GET_TICKETS, {
+    fetchPolicy: 'cache-and-network',
+  });
+
+  let messages: Array<any> = [];
+  const numOfItemsPerPage: number = 5;
+
+  if (data) {
+    const previousMessages = data?.getAllTickets?.slice(
+      0,
+      page * numOfItemsPerPage,
+    );
+
+    const nextPage = data?.getAllTickets?.slice(
+      page * numOfItemsPerPage,
+      (page + 1) * numOfItemsPerPage,
+    );
+    messages = [...previousMessages, ...nextPage];
+  }
+
+  return (
+    <div className="flex flex-col grow items-center bg-light-bg dark:bg-dark-frame-bg">
+      <div className="flex flex-col items-center gap-4 sm:w-[90%] md:w-[70%] lg:w-[45%] lg:ml-[38vh] mt-5 lg:mr-[2vh] lg:mb-10 pt-12">
+        <h2 className="text-4xl font-bold dark:text:white mb-3">
+          {t('Tickets')}
+        </h2>
+
+        {loading ? (
+          <>
+            <div className="w-full bg-white rounded overflow-hidden shadow-xl">
+              <CustomSkeleton />
+            </div>
+            <div className="w-full bg-white rounded overflow-hidden shadow-xl">
+              <CustomSkeleton />
+            </div>
+            <div className="w-full bg-white rounded overflow-hidden shadow-xl">
+              <CustomSkeleton />
+            </div>
+          </>
+        ) : (
+          data &&
+          messages.map((msg: any) => (
+            <div
+              // eslint-disable-next-line no-underscore-dangle
+              key={String(msg._id)}
+              className="w-full bg-white dark:bg-dark-bg rounded overflow-hidden shadow-xl"
+            >
+              <div className="px-6 py-8">
+                <div className="font-bold text-xl text-blue-600 mb-5">
+                  {msg.user.firstName} {msg.user.lastName}
+                  <span className="block text-sm font-thin text-gray-500 mt-0 dark:text-white">
+                    {msg.user.email}
+                  </span>
+                </div>
+                <p className="text-gray-800 font-semibold text-lg mb-2 dark:text-white">
+                  {msg.subject}
+                </p>
+                <p className="text-gray-700 break-keep text-base dark:text-white">
+                  {msg.message}
+                </p>
+              </div>
+              <div className="flex flex-row justify-between px-6 pt-0 pb-6">
+                <span className="bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded">
+                  {msg.status}
+                </span>
+
+                <span className="text-gray-500 text-sm font-medium mr-2 px-2.5 py-0.5 rounded dark:text-white">
+                  {timePassedCalculator(new Date(+msg.createdAt))}
+                </span>
+              </div>
+            </div>
+          ))
+        )}
+
+        {messages?.length === data?.getAllTickets?.length ? (
+          <span className="block text-base font-thin text-gray-500 mt-0">
+            {t('No more tickets found!')}
+          </span>
+        ) : (
+          <Button
+            type="submit"
+            variant="primary"
+            data-testid="loginForm"
+            size="lg"
+            style="ml-0 hover:bg-cyan-700 text-sm"
+            onClick={() => setPage((page) => page + 1)}
+          >
+            {t('Load more')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Tickets;

--- a/src/queries/tickets.queries.tsx
+++ b/src/queries/tickets.queries.tsx
@@ -1,0 +1,20 @@
+import { gql } from '@apollo/client';
+
+const GET_TICKETS = gql`
+  query GetAllTickets {
+    getAllTickets {
+      _id
+      message
+      subject
+      status
+      createdAt
+      user {
+        firstName
+        lastName
+        email
+      }
+    }
+  }
+`;
+
+export default GET_TICKETS;

--- a/src/utils/timePassedFormating.ts
+++ b/src/utils/timePassedFormating.ts
@@ -1,0 +1,32 @@
+function timePassedCalculator(date: any) {
+  const passedDate: any = new Date(date);
+  const diffInMilliSeconds: number = Math.abs(passedDate - Date.now()) / 1000;
+
+  // calculate days
+  const days = Math.floor(diffInMilliSeconds / 86400);
+  if (days === 1) return 'Yesterday';
+  if (days > 10)
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(date));
+  if (days > 0) return `${days} days ago.`;
+
+  // calculate hours
+  const hours = Math.floor(diffInMilliSeconds / 3600) % 24;
+  if (hours === 1) return 'An hour ago';
+  if (hours > 0) return `${hours} hours ago.`;
+
+  // calculate minutes
+  const minutes = Math.floor(diffInMilliSeconds / 60) % 60;
+  if (minutes === 1) return 'A minute ago';
+  if (minutes > 0) return `${minutes} minutes ago.`;
+
+  // Return Seconds
+  if (diffInMilliSeconds === 1) return 'A second ago';
+  return `${Math.floor(diffInMilliSeconds)} seconds ago.`;
+}
+
+export default timePassedCalculator;


### PR DESCRIPTION
# PR description
PR used creating a help page for the use for the asking the support or feedback
implementation of the help page so that it can help the use to raise the issue and feedback

# Description of tasks that were expected to be completed

- [x] design of the help page
- [x] Submitting it should open a ticket in superadmin account
- [x] superadmin menu has a tickets item
- [x] Tickets appear on the dashboard

# How has this been tested?
`/dashbord/support`
- Pull this pr in local machine
- Set **BAKEND_URL** to `https://devpulse-backend-pr-98.onrender.com/`
- Signin and go on `dashboard/support`
- Submit a message a message
- Sign out and signin as **superadmin**
- Go to `dashboard/ inquiries`

#### Screenshoots

`Help page`

![Screenshot (83)](https://github.com/atlp-rwanda/atlp-pulse-fn/assets/55640083/87021451-1d43-47ed-8703-f736fa3de5ee)


`Inquiries`

![Screenshot (91)](https://github.com/atlp-rwanda/atlp-pulse-fn/assets/55640083/9be2a292-a823-4263-879f-958abb4b22ed)
