### PR TITLE
fix: Replace buttons with icons on organizations page

### DIFF
--- a/src/components/Organizations.tsx
+++ b/src/components/Organizations.tsx
@@ -79,63 +79,67 @@ function ActionButtons({
         <div className="flex relative flex-row align-middle justify-center items-center">
             {checkStatus == 'active' ? (
                 <>
-                    <div
-                        //   data-testid="traineeIcon"
-                        onClick={() => {
-                            setData(getData?.getOrganizations[props.row.index]);
-                            console.log(getData?.getOrganizations[props.row.index])
-                            removeInviteModel();
-                        }}
-                    >
-                        <Icon
-                            icon="mdi:refresh"
-                            // className="mr-2"
-                            width="30"
-                            height="30"
-                            cursor="pointer"
-                            color="#148fb6"
-                        />
-                    </div>
-                    <div
-                        //   data-testid="updateIcon"
-                        onClick={() => {
-                            setData(getData?.getOrganizations[props.row.index]);
-                            removeDeleteModel();
-                        }}
-                    >
-                        <Icon
-                            icon="mdi:close-circle-outline"
-                            // className="mr-2"
-                            width="30"
-                            height="30"
-                            cursor="pointer"
-                            color="#148fb6"
-                        />
-                    </div>
+                  <div
+                    onClick={() => {
+                      setData(getData?.getOrganizations[props.row.index]);
+                      console.log(getData?.getOrganizations[props.row.index])
+                      removeInviteModel();
+                    }}
+                  >
+                    <Icon
+                      icon="mdi:email-fast"
+                      width="30"
+                      height="30"
+                      cursor="pointer"
+                      color="#9e85f5"
+                    />
+                  </div>
+                  <div
+                    onClick={() => {
+                      setData(getData?.getOrganizations[props.row.index]);
+                      removeDeleteModel();
+                    }}
+                  >
+                    <Icon
+                      icon="mdi:delete"
+                      width="30"
+                      height="30"
+                      cursor="pointer"
+                      color="#9e85f5"
+                    />
+                  </div>
                 </>
             ) : (
-                <>
-                    <Button
-                        variant="primary"
-                        size="sm"
-                        onClick={() => {
-                            setData(getData?.getOrganizations[props.row.index]);
-                            approveModel();
-                        }}
-                    >
-                        Approve
-                    </Button>
-                    <Button
-                        variant="primary"
-                        size="sm"
-                        onClick={() => {
-                            setData(getData?.getOrganizations[props.row.index]);
-                            rejectModel();
-                        }}
-                    >
-                        Reject
-                    </Button>
-                </>
+              <>
+                <div
+                  onClick={() => {
+                    setData(getData?.getOrganizations[props.row.index]);
+                    approveModel();
+                  }}
+                >
+                  <Icon
+                    icon="mdi:bank-check"
+                    width="30"
+                    height="30"
+                    cursor="pointer"
+                    color="#9e85f5"
+                  />
+                </div>
+                <div
+                  onClick={() => {
+                    setData(getData?.getOrganizations[props.row.index]);
+                    rejectModel();
+                  }}
+                >
+                  <Icon
+                    icon="mdi:bank-remove"
+                    width="30"
+                    height="30"
+                    cursor="pointer"
+                    color="#9e85f5"
+                  />
+                </div>
+              </>
             )}
         </div>
     );


### PR DESCRIPTION
# PR Description

This pull request contains changes to be made on the organizations page of the super admin dashboard.

# Description of tasks that were expected to be completed

- [x] Change action buttons to specific icons
- [x] Change icon colors to our platform color codes for design consistency

# How has this been tested?

This PR can be tested by loging into the super admin dashboard and going to the organizations page.
On that page, the current action icons reflect the specific actions that they represent, and they have the same colors as the rest of the other buttons on our platform.

# Number of Commits

1

# Screenshots (If appropriate)

<img width="1440" alt="Screenshot 2023-10-06 at 16 24 24" src="https://github.com/atlp-rwanda/atlp-pulse-fn/assets/69908528/b85661d1-a7bf-4300-afa8-96029bb9535b">

# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code generate no warnings
- [x] My test coverage meet the set test coverage threshold
- [x] There are no vulnerabilities
- [x] There are no conflicts with the base branch
