### PR TITLE
Admin get coordinators

### DIFF
--- a/src/containers/admin-dashBoard/CoordinatorModal.tsx
+++ b/src/containers/admin-dashBoard/CoordinatorModal.tsx
@@ -5,8 +5,8 @@ import DataTable from '../../components/DataTable';
 import Spinner from '../../components/Spinner';
 
 const GET_COORDINATORS = gql`
-  query Query {
-    getAllCoordinators {
+  query Query ($orgToken: String){
+    getAllCoordinators(orgToken: $orgToken) {
       email
       profile {
         name
@@ -28,28 +28,18 @@ interface Coordinator {
 
 export default function CoordinatorsPage() {
   const { t } = useTranslation();
-
+  const orgToken = localStorage.getItem('orgToken');
   const { loading, error, data } = useQuery(GET_COORDINATORS, {
+    variables: {
+      orgToken: orgToken,
+    },
     pollInterval: 3000, // Refresh every 3 seconds
   });
   const [coordinators, setCoordinators] = useState<Coordinator[]>([]);
 
-  const organizationName = localStorage.getItem('orgName') as string;
   useEffect(() => {
     if (data) {
-      // remove organizations that the admin doesn't belongs to;
-      const newData = data.getAllCoordinators.filter((coordinator:any)=>{
-        let neededAdminOrganisations:any = null;
-        coordinator.organizations.forEach((singleOrganization: string)=> {
-          if (singleOrganization === organizationName) {
-            neededAdminOrganisations = coordinator;
-          }
-        });
-        return neededAdminOrganisations;
-      });
-      console.log(newData);
-
-      const extractedCoordinators = newData?.map(
+      const extractedCoordinators = data.getAllCoordinators.map(
         (coordinator: any) => ({
           email: coordinator.email,
           profile: coordinator.profile || { name: null },
@@ -57,10 +47,16 @@ export default function CoordinatorsPage() {
           role: coordinator.role,
         }),
       );
-    
+
       setCoordinators(extractedCoordinators);
     }
   }, [data]);
+
+
+
+  
+
+
 
   const columns = [
     {

--- a/src/containers/admin-dashBoard/CoordinatorModal.tsx
+++ b/src/containers/admin-dashBoard/CoordinatorModal.tsx
@@ -34,9 +34,22 @@ export default function CoordinatorsPage() {
   });
   const [coordinators, setCoordinators] = useState<Coordinator[]>([]);
 
+  const organizationName = localStorage.getItem('orgName') as string;
   useEffect(() => {
     if (data) {
-      const extractedCoordinators = data.getAllCoordinators.map(
+      // remove organizations that the admin doesn't belongs to;
+      const newData = data.getAllCoordinators.filter((coordinator:any)=>{
+        let neededAdminOrganisations:any = null;
+        coordinator.organizations.forEach((singleOrganization: string)=> {
+          if (singleOrganization === organizationName) {
+            neededAdminOrganisations = coordinator;
+          }
+        });
+        return neededAdminOrganisations;
+      });
+      console.log(newData);
+
+      const extractedCoordinators = newData?.map(
         (coordinator: any) => ({
           email: coordinator.email,
           profile: coordinator.profile || { name: null },
@@ -44,10 +57,7 @@ export default function CoordinatorsPage() {
           role: coordinator.role,
         }),
       );
-      // .filter((coordinator: Coordinator) => {
-      //   const orgName = localStorage.getItem('orgName') as string;
-      //   return coordinator.organizations.includes(orgName);
-      // });
+    
       setCoordinators(extractedCoordinators);
     }
   }, [data]);


### PR DESCRIPTION
# PR Description
Admin from specific company can be able to see the coordinators from that company only

# Description of tasks that were expected to be completed

My task was for the admin to be able to log in and be able to get coordinators from his company only.

# How has this been tested?

You have to select a specific company. After, you have to include the admin credentials to log in. Then, you have to go in coordinators and be able to see coordinators from your company only


# Screenshots (If appropriate)

![Screen Shot 2023-11-24 at 20 08 00](https://github.com/atlp-rwanda/atlp-pulse-fn/assets/77435896/b9d802fc-9480-4fce-886f-a2fba63bad4e)
![Screen Shot 2023-11-24 at 20 12 16](https://github.com/atlp-rwanda/atlp-pulse-fn/assets/77435896/d8ff46d2-57ba-493c-8dde-07f73637a3bf)

