### PR TITLE
#433 Ft Invitation Statistics Fe

### DIFF
--- a/src/Mutations/invitationStats.tsx
+++ b/src/Mutations/invitationStats.tsx
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client';
+export const GET_INVITATIONS_STATISTICS_QUERY = gql`
+  query GetInvitationStatistics($orgToken: String!){
+    getInvitationStatistics(orgToken: $orgToken){
+      totalInvitations
+      pendingInvitationsCount
+      getPendingInvitationsPercentsCount
+      getAcceptedInvitationsPercentsCount
+      acceptedInvitationsCount
+    }
+  }
+`;


### PR DESCRIPTION
# PR Description

This PR focuses on integrating the frontend  for displaying invitation statistics with the existing graphql API.
Its feature includes cards showing the number of accepted, pending, denied, and all invitations. Users can filter the data based on time ranges (last 7 days, last 30 days, last 90 days, or a custom range).

# Description of tasks that were expected to be completed

- [ ] Integrated the InvitationCard component with the GraphQL API to display invitation statistics.
- [ ] Used Apollo Client for fetching data from the backend and handled loading states, errors, and refetching.
- [ ] Ensured that the existing UI layout remains intact while adding functionality to fetch real-time data.


# How has this been tested?

Clone the rep cd into it,  checkout the branch **ft-statistics-Fe-#433**  run then run npm install to install dependences, then nun **npm dev** to start the server .  or test it using this link https://metron-devpulse-git-ft-statistics-fe-433-metron.vercel.app/

- Log in as an admin using this credetional;  email:devpulse@proton.me , Password: Test@12345
-  visit invitation page.

# Screenshots (If appropriate)
![image](https://github.com/user-attachments/assets/935c67a7-1e03-4356-ba16-d793972cb32f)



