### PR TITLE
fixing fetching invitations for specific organization

### DIFF
--- a/src/pages/invitation.tsx
+++ b/src/pages/invitation.tsx
@@ -213,9 +213,15 @@ function Invitation() {
 
   useEffect(() => {
     if (filterVariables.role || filterVariables.status) {
-      filterInvitations();
+      filterInvitations({
+          variables: {
+          role: filterVariables.role || null,
+          status: typeof filterVariables.status === 'string' ? filterVariables.status : null,
+          orgToken: organizationToken,
+        },
+    });
     }
-  }, [filterVariables, filterInvitations]);
+  }, [filterVariables, filterInvitations,organizationToken]);
 
   // Consolidated effect to handle query and search data
   useEffect(() => {
@@ -278,7 +284,10 @@ function Invitation() {
     setError(null);
     setLoading(false);
 
-    setFilterVariables({ role: selectedRole, status: selectedStatus });
+      setFilterVariables({
+      role: selectedRole,
+      status: typeof selectedStatus === 'string' ? selectedStatus : '',
+    });
   };
 
   const toggleOptions = (row: string) => {

--- a/src/queries/invitation.queries.tsx
+++ b/src/queries/invitation.queries.tsx
@@ -33,8 +33,8 @@ export const GET_INVITATIONS = gql`
 `;
 
 export const GET_ROLES_AND_STATUSES = gql`
-  query filterInvitations($limit: Int, $offset: Int, $role: String, $status: String) {
-    filterInvitations(limit: $limit, offset: $offset, role: $role, status: $status) {
+  query filterInvitations($limit: Int, $offset: Int, $role: String, $status: String, $orgToken: String!) {
+    filterInvitations(limit: $limit, offset: $offset, role: $role, status: $status, orgToken: $orgToken) {
       invitations {
         invitees {
           email


### PR DESCRIPTION
# PR Description

This PR includes fix on filtering users based on a specific organisation as well as specific admin

# Description of tasks that were expected to be completed
1. Filtering based on the organisation name

# How has this been tested?

1. Clone the repository using `git clone`
Navigate to the branch using `git checkout fx-invitation-filter`
Run `npm run dev` in the terminal

2. Using [this](https://metron-devpulse-git-fx-invitation-filter-metron.vercel.app/) link
Use admin credentials:devpulse@proton.me password:Test@12345
# Number of Commits
1 commit

# Screenshots (If appropriate)
![a1](https://github.com/user-attachments/assets/69e05b88-6acd-442d-8bca-c8195d5902b2)
![a2](https://github.com/user-attachments/assets/549e6f5b-78de-4d24-9fa1-104d60ae7589)

# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code generate no warnings
- [x] My test coverage meet the set test coverage threshold
- [x] There are no vulnerabilities
- [x] There are no conflicts with the base branch
