### PR TITLE
admin should be able to resend pending invitations 

### DIFF
--- a/src/Mutations/invitationMutation.tsx
+++ b/src/Mutations/invitationMutation.tsx
@@ -69,3 +69,13 @@ export const CANCEL_INVITATION = gql`
     }
   }
 `;
+
+export const RESEND_INVITATION = gql`
+  mutation ResendInvitation($invitationId: ID!, $orgToken: String!) {
+    resendInvitation(invitationId: $invitationId, orgToken: $orgToken) {
+      success
+      message
+    }
+  }
+`;
+

--- a/src/pages/invitation.tsx
+++ b/src/pages/invitation.tsx
@@ -19,6 +19,7 @@ import {
   CANCEL_INVITATION,
   DELETE_INVITATION,
   UPDATE_INVITATION,
+  RESEND_INVITATION
 } from '../Mutations/invitationMutation';
 import Button from '../components/Buttons';
 import {
@@ -55,6 +56,7 @@ function Invitation() {
     startDate: '',
     endDate: '',
   });
+  const [resendInvitationModel,setResendInvatationModel]= useState(false)
   const { t }: any = useTranslation();
   const removeInviteeMod = () => {
     const newState = !removeInviteeModel;
@@ -69,6 +71,7 @@ function Invitation() {
   const [selectedRow, setSelectedRow] = useState<string | null>(null);
   const [removeInviteeModel, setRemoveInviteeModel] = useState(false);
   const [deleteInvitation, setDeleteInvitation] = useState('');
+  const[invitationToResend,setInvitationToResend]=useState('')
   const [updateInviteeModel, setUpdateInviteeModel] = useState(false);
   const [buttonLoading, setButtonLoading] = useState(false);
   const [selectedRole, setSelectedRole] = useState('');
@@ -429,7 +432,12 @@ function Invitation() {
 
                   {row.original.Status === 'Pending' && (
                     <div className="mb-4">
-                      <div className="flex items-center p-2 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800">
+                      <div className="flex items-center p-2 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+                      onClick={() => {
+                        setResendInvatationModel(true);
+                        setInvitationToResend(row.original.id);
+                        toggleOptions(row.original.email);
+                      }}>
                         <Icon
                           icon="mdi:arrow-up-circle"
                           width="40"
@@ -498,6 +506,28 @@ function Invitation() {
       </>
     );
   }
+
+  const [ResendInvitation]=useMutation(RESEND_INVITATION,{
+    variables:{
+      invitationId:invitationToResend,
+      orgToken:organizationToken 
+    },
+      onCompleted:(data)=>{
+        setTimeout(()=>{
+          setButtonLoading(false);
+          toast.success(data.resendInvitation.message);
+          refetch();
+          setResendInvatationModel(false)
+        })
+      }
+      ,onError:(error)=>{
+        setTimeout(() => {
+          setButtonLoading(false);
+          toast.error(error.message);
+        }, 500);
+      }
+
+  })
 
   const [DeleteInvitation] = useMutation(DELETE_INVITATION, {
     variables: {
@@ -622,7 +652,7 @@ function Invitation() {
             className="lg:bg-[#9e85f5] bg-none lg:text-white text-[#9e85f5] text-lg lg:text-lg rounded-md h-10 flex items-center justify-center w-[27%]"
           >
             <IoIosAddCircleOutline className="w-6 h-6 md:w-8 md:h-8 md:mr-2 xm:w-8 xm:h-8 sm:w-10 sm:h-10" />
-            <span className="hidden lg:block">Invite User</span>
+            <span className="hidden lg:block text-sm">Invite User</span>
           </button>
         </div>
       </div>
@@ -1013,6 +1043,60 @@ function Invitation() {
                   loading={buttonLoading}
                 >
                   {t('Update')}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+      {/* resend invitation modal */}
+
+      <div
+        className={`h-screen w-screen bg-black bg-opacity-30 backdrop-blur-sm fixed top-0 left-0 z-20 flex items-center justify-center  px-4 ${
+          resendInvitationModel === true ? 'block' : 'hidden'
+        }`}
+      >
+        <div className="w-full p-4 pb-8 bg-white rounded-lg dark:bg-dark-bg sm:w-3/4 xl:w-4/12">
+          <div className="flex flex-wrap items-center justify-center w-full card-title ">
+            <h3 className="w-11/12 text-sm font-bold text-center dark:text-white ">
+              {t('Resend Invitation')}
+            </h3>
+            <hr className="w-full my-3 border-b bg-primary" />
+          </div>
+          <div className="card-body">
+            <form className="px-8 py-3 ">
+              <div className="flex flex-wrap items-center justify-center w-full card-title ">
+                <h3 className="w-11/12 text-sm font-bold text-center dark:text-white ">
+                  {t('Are you sure you want to Resend this invitation?')}
+                </h3>
+              </div>
+
+              <div className="flex justify-between w-full">
+                <Button
+                  data-testid="removeModel2"
+                  variant="info"
+                  size="sm"
+                  style="w-[40%] md:w-1/4 text-sm font-sans"
+                  onClick={() => setResendInvatationModel(false)}
+                >
+                  {t('Cancel')}
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  data-testid="removeMemberFromCohort"
+                  style="w-[40%] md:w-1/4 text-sm font-sans"
+                  onClick={() => {
+                    setButtonLoading(true);
+                    if (invitationToResend) {
+                      ResendInvitation();
+                    } else {
+                      toast.error('No invitation selected');
+                    }
+                  }}
+                  loading={buttonLoading}
+                >
+                  {t('Proceed')}
                 </Button>
               </div>
             </form>


### PR DESCRIPTION
### PR Description
This pr  Adds a feature to  resend invitations that have been Pending
### Description of tasks that were expected to be completed
 As an admin, should be able to resend  pending invitations  in his/her organization .
### Functionality
In case  there is invitations that have pending status , an admin may need to resend them, that's when the feature comes in, it is applicable  only to invitations in pending status
### How has this been tested?
Clone [this ](https://github.com/atlp-rwanda/atlp-pulse-fn) repo , cd into it, checkout the branch _ft-resend-invitation_  then run the follwoing commands :
- npm install : to install dependencies 
- npm run dev to start the server;
Or you can test this feature by using the deployed link https://metron-devpulse-git-ft-resend-invitation-metron.vercel.app/  

Login in as admin by using the following credetials  Organization:Andela, email:[devpulse@proton.me], password:Test@12345. Try to resend pending invitations.

Trello Link (#472)

![Screenshot from 2024-10-03 14-09-02](https://github.com/user-attachments/assets/ea941548-5758-443c-b13c-e3056544deae)

<img width="1425" alt="Screenshot 2024-10-04 at 07 43 01" src="https://github.com/user-attachments/assets/501c2e44-81fd-487a-818d-0c493bbe17d5">


![Screenshot from 2024-10-03 14-09-40](https://github.com/user-attachments/assets/9422994a-5fb3-44fa-b968-4b9385e402ac)


