### PR TITLE
#559 Disable filter button when no role or status selected .

### DIFF
--- a/src/pages/invitation.tsx
+++ b/src/pages/invitation.tsx
@@ -83,6 +83,7 @@ function Invitation() {
     role: '',
     status: '',
   });
+  const[filterDisabled,setFilterDisabled]=useState<boolean>(true)
   const modalRef = useRef<any>(null);
 
   const organizationToken = localStorage.getItem('orgToken');
@@ -133,7 +134,7 @@ function Invitation() {
 
   useEffect(() => {
     if (invitationStats) {
-      setSelectedStatus(invitationStats); // Set the fetched status as the default value
+      setSelectedStatus(''); // Set the fetched status as the default value
     }
   }, [invitationStats]);
 
@@ -219,7 +220,7 @@ function Invitation() {
       filterInvitations({
           variables: {
           role: filterVariables.role || null,
-          status: typeof filterVariables.status === 'string' ? filterVariables.status : null,
+          status:filterVariables.status || null,
           orgToken: organizationToken,
         },
     });
@@ -277,6 +278,27 @@ function Invitation() {
     fetchInvitations({ variables: { query: searchQuery } });
   };
 
+
+  useEffect(() => {
+    if (selectedRole || selectedStatus) {
+      setFilterDisabled(false);
+    } else {
+      setFilterDisabled(true);
+    }
+  }, [selectedRole, selectedStatus]);
+
+const handleRoleChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
+  const role=e.target.value
+  setSelectedRole(role)
+ 
+}
+
+const handleStatusChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
+  const status=e.target.value
+    setSelectedStatus(status)
+
+}
+
   const handleFilter = () => {
     if (!selectedRole && !selectedStatus) {
       toast.info('Please select role or status.');
@@ -291,6 +313,7 @@ function Invitation() {
       role: selectedRole,
       status: typeof selectedStatus === 'string' ? selectedStatus : '',
     });
+ 
   };
 
   const toggleOptions = (row: string) => {
@@ -364,7 +387,8 @@ function Invitation() {
               className="absolute z-50 w-64 p-4 mt-2 overflow-hidden border border-gray-300 rounded-lg shadow-md dropdown right-4 bg-light-bg max-h-30 dark:bg-dark-bg">
               <>
                   <div className="mb-4"></div>
-                  <div className="mb-4">
+
+                  { row.original.Status === 'Pending' &&<div className="mb-4">
                     <div
                       className="flex items-center p-2 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
                       onClick={() => {
@@ -388,6 +412,7 @@ function Invitation() {
                       </div>
                     </div>
                   </div>
+                    }
 
                   {/* Conditionally render Cancel button */}
                   {row.original.Status === 'Pending' && (
@@ -803,7 +828,7 @@ function Invitation() {
             type="button"
             disabled={disabledSearch}
             onClick={handleSearch}
-            className="bg-[#9e85f5] text-white text-lg md:text-xl rounded-md h-10 flex items-center justify-center  md:w-[10%] p-0 sm:p-5 xm:p-5"
+            className={`bg-[#9e85f5] text-white text-lg md:text-xl rounded-md h-10 flex items-center justify-center  md:w-[10%] p-0 sm:p-5 xm:p-5 ${disabledSearch?'cursor-not-allowed opacity-50':'cursor-pointer'}`}
           >
             Search
           </button>
@@ -819,9 +844,9 @@ function Invitation() {
           </p>
           <span className="w-full md:w-auto">
             <select
-              className="w-full max-w-xs px-2 py-1 text-gray-700 bg-transparent border border-gray-300 rounded outline-none md:w-auto dark:text-white dark:text:text-white"
+              className="w-full max-w-xs px-2 py-1 text-gray-700 bg-transparent border border-gray-300 rounded outline-none md:w-auto dark:text-white dark:text:text-white dark:bg-[#04122F]"
               value={selectedRole}
-              onChange={(e) => setSelectedRole(e.target.value)}
+              onChange={handleRoleChange}
             >
               <option value="">-</option>
               <option value="trainee">trainee</option>
@@ -837,9 +862,9 @@ function Invitation() {
           </span>
           <span className="w-full md:w-auto">
             <select
-              className="w-full max-w-xs px-2 py-1 text-gray-700 bg-transparent border border-gray-300 rounded outline-none md:w-auto dark:text-white"
+              className="w-full max-w-xs px-2 py-1 text-gray-700 bg-transparent border border-gray-300 rounded outline-none md:w-auto dark:text-white dark:bg-[#04122F]"
               value={selectedStatus}
-              onChange={(e) => setSelectedStatus(e.target.value)}
+              onChange={ handleStatusChange}
             >
               <option value="">-</option>
               <option value="pending">pending</option>
@@ -849,13 +874,15 @@ function Invitation() {
             </select>
           </span>
           <button
-            type="button"
-            // disabled={disabled}
-            onClick={handleFilter}
-            className="w-full max-w-xs md:w-auto bg-[#9e85f5] text-white text-lg md:text-xl rounded-md h-10 flex items-center justify-center px-4 py-2"
-          >
-            Filter
-          </button>
+  type="button"
+  disabled={filterDisabled}
+  onClick={handleFilter}
+  className={`w-full max-w-xs md:w-auto bg-[#9e85f5] text-white text-lg md:text-xl rounded-md h-10 flex items-center justify-center px-4 py-2 
+    ${filterDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+>
+  Filter
+</button>
+
         </div>
         {/* Table view */}
         {content}


### PR DESCRIPTION
# PR Description
Filter  button is disabled by default,and it gets enabled when role or status is selected and update invitation action  is only  available on pending invitations

# Description of tasks that were expected to be completed

1.  Filter  button is disabled by default
2. Update action only available on pending invitations

    
# How has this been tested?
Clone this repository, checkout the this branch, then install  all dependencies
login in the app  with the following credentials and test the above mentioned features on the invitations page
 **Link**https://metron-devpulse-git-ft-disable-filter-btn-default-559-metron.vercel.app/invitation
**Organization**:Andela
**email**:devpulse@proton.me
**password**:Test@12345

# Screenshots (If appropriate)
![Screenshot from 2024-10-09 10-10-08](https://github.com/user-attachments/assets/2800e699-fa0a-40be-b03f-da97e01f0544)
![Screenshot from 2024-10-09 10-09-28](https://github.com/user-attachments/assets/4003dc93-2e07-4019-a801-e6a5fea4bd9c)
![Screenshot from 2024-10-09 10-09-14](https://github.com/user-attachments/assets/b5f57726-44f1-4e5e-8c36-f05b9a241637)


# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code generate no warnings
- [x] My test coverage meet the set test coverage threshold
- [x] There are no vulnerabilities
- [x] There are no conflicts with the base branch
