### PR TITLE
#580 Update dark background color on desktop  to match with on mobile design

### DIFF
--- a/src/components/InvitationCard.tsx
+++ b/src/components/InvitationCard.tsx
@@ -13,20 +13,20 @@ interface InvitationCardType {
 // Define the InvitationCard component using a function declaration
 function InvitationCard({ icon, status, time, staticNumber, percentage }: InvitationCardType) {
   return (
-    <div className='bg-blue-100 lg:dark:bg-blue-100 sm:dark:bg-[#0A1729] xm:dark:bg-[#0A1729] w-full grid h-36 text-black shadow-lg rounded-lg m-auto'>
+    <div className='bg-blue-100 lg:dark:bg-[#0A1729] sm:dark:bg-[#0A1729] xm:dark:bg-[#0A1729] w-full grid h-36 text-black shadow-lg rounded-lg m-auto'>
 
         <div className='flex flex-row gap-3 mt-4 sm:gap-1'>
           <div className='flex w-8 h-10 ml-2'>
             {icon}
           </div>
-          <h3 className='text-md md:text-md lg:text-xl font-Inter font-bold text-[12px] sm:dark:text-white xm:dark:text-white lg:dark:text-black'>{status}</h3>
+          <h3 className='text-md md:text-md lg:text-xl font-Inter font-bold text-[12px] sm:dark:text-white xm:dark:text-white lg:dark:text-white'>{status}</h3>
         </div>
         <div>
           <p className='-mt-10 ml-12 text-[12px] font-inter text-gray-500 font-inter sm:-[8px]'>{time}</p>
         </div>
 
       <div className='flex items-center justify-center -mt-10 '>
-        <div className='font-bold -mt-4 ml-0 sm:ml-5 text-[30px] md:text-[40px] sm:dark:text-white xm:dark:text-white lg:dark:text-black'>{staticNumber}
+        <div className='font-bold -mt-4 ml-0 sm:ml-5 text-[30px] md:text-[40px] sm:dark:text-white xm:dark:text-white lg:dark:text-white'>{staticNumber}
         </div>
         <div className='text-base text-[#7258ce] ml-3 mb-4'>
           <AiOutlineRise className="text-xl" data-testid="ai-outline-user"/>


### PR DESCRIPTION
# PR Description

This pull request updates the invitation statistics cards to match the background color on desktop with the mobile design.

# Description of tasks that were expected to be completed
 -  Changed the dark background color on desktop design to match mobile 
 -  Ensured the Text color matches on both side
 -  Ensure responsiveness are maintained

# How has this been tested?

Clone this repo, cd into it ,checkout the branch ft-improve-invitation-statsCard then run :
 - npm install : to install dependences
 - npm run dev to start the server

or use this deployed link: http://metron-devpulse-git-ft-improve-invitation-statscard-metron.vercel.app 

 ##### log in with credential:
- Email: devpulse@proton.me
- password: Test@12345

# Number of Commits

1 Commit

# Screenshots (If appropriate)
#### On desktop 
![image](https://github.com/user-attachments/assets/eeae3700-b78e-45d6-9f0c-44d5f65feb34)


#### On mobile
![image](https://github.com/user-attachments/assets/ea2879a3-890e-4e13-956b-f97eb676f81b)

# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code generate no warnings
- [x] My test coverage meet the set test coverage threshold
- [x] There are no vulnerabilities
- [x] There are no conflicts with the base branch
