### PR TITLE
next redirect

### DIFF
--- a/src/utils/ProtectRoute.tsx
+++ b/src/utils/ProtectRoute.tsx
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 import React, { ReactNode, useContext } from 'react';
-import { Navigate, Routes } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { UserContext } from '../hook/useAuth';
 
 interface Props {
@@ -11,8 +11,14 @@ interface Props {
 
 function ProtectedUserRoute({ children, roles = [], ...props }: Props) {
   const { user } = useContext(UserContext);
-  if (roles?.includes(user?.role) || roles.length === 0) return <>{children}</>;
-  return <Navigate {...props} to="/dashboard" />;
+  const location = useLocation();
+
+  if (roles?.includes(user?.role) || roles.length === 0) {
+    return <>{children}</>;
+  }
+
+  // Redirect to login if user is not authenticated, and append the current path
+  return <Navigate {...props} to={`/login?redirect=${location.pathname}`} />;
 }
 
 export default ProtectedUserRoute;


### PR DESCRIPTION
# PR Description

This PR resolves the issue where users are not redirected to the correct URL after logging in when a token has expired.


# How has this been tested?

- Visit a protected URL (e.g., https://beta.devpulse.org/invitation) without being logged in.
- You will be redirected to the login page.
- Log in with correct credentials.
- You should now be redirected back to the originally requested URL (/invitation) instead of the default URL (/trainees).

# Number of Commits

The number of commits should not exceed **2 commits**. In case they are more than that, please take your time and squash them.

# Screenshots (If appropriate)

# Please check this Checklist before you submit your PR:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code generate no warnings
- [ ] My test coverage meet the set test coverage threshold
- [ ] There are no vulnerabilities
- [ ] There are no conflicts with the base branch
