### PR TITLE
#581 sort invitations

### DIFF
--- a/src/pages/invitation.tsx
+++ b/src/pages/invitation.tsx
@@ -42,6 +42,7 @@ interface Invitationn {
 
 function Invitation() {
   const [invitationStats, setInvitationStats] = useState<any>(null);
+  const [sortBy,setSortBy]=useState<number>(-1)
   const [invitations, setInvitations] = useState<Invitationn[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -127,6 +128,7 @@ function Invitation() {
   } = useQuery(GET_ALL_INVITATIONS, {
     variables:{
       orgToken: organizationToken,
+      sortBy:sortBy
     },
     fetchPolicy: 'network-only',
   });
@@ -202,6 +204,7 @@ function Invitation() {
     variables: {
      query: searchQuery,
      orgToken: organizationToken,
+     sortBy:sortBy
     },
     fetchPolicy: 'network-only',
   });
@@ -220,6 +223,7 @@ function Invitation() {
           role: filterVariables.role || null,
           status:filterVariables.status || null,
           orgToken: organizationToken,
+          sortBy:sortBy
         },
     });
     }
@@ -300,7 +304,6 @@ const handleStatusChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
       toast.info('Please select role or status.');
       return;
     }
-
     setInvitations([]);
     setError(null);
     setLoading(false);
@@ -309,6 +312,11 @@ const handleStatusChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
       role: selectedRole,
       status: typeof selectedStatus === 'string' ? selectedStatus : '',
     });
+    filterInvitations({
+      variables:{
+        sortBy:sortBy
+      }
+    })
  
   };
 
@@ -631,6 +639,18 @@ const handleStatusChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
       }, 500);
     },
   });
+
+
+  useEffect(()=>{
+      refetch()
+   
+  },[sortBy])
+const  changeSortQuery=(e:React.ChangeEvent<HTMLSelectElement>)=>{
+let sortBy=parseInt(e.target.value)
+setSortBy(sortBy)
+
+}
+
   return (
     <div className="w-full ">
       {/* Header and Invite Button */}
@@ -826,12 +846,12 @@ const handleStatusChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
               <div>
                 <select
                     className="w-full max-w-xs sm:px-2 px-0 py-1 text-gray-700 bg-transparent border border-gray-300 rounded outline-none md:w-auto dark:text-white dark:text:text-white dark:bg-[#04122F]"
-                    value={selectedSort}
-                    onChange={(e) => setSelectedSort(e.target.value)}
+                    value={sortBy}
+                    onChange={changeSortQuery}
                   >
                     <option value="">Sort by</option>
-                    <option value="newest">Newest</option>
-                    <option value="oldest">Oldest</option>
+                    <option value="-1">Newest</option>
+                    <option value="1">Oldest</option>
                 </select>
               </div>
             </div>

--- a/src/queries/invitation.queries.tsx
+++ b/src/queries/invitation.queries.tsx
@@ -2,8 +2,8 @@ import { gql } from "@apollo/client";
 
 
 export const GET_ALL_INVITATIONS = gql`
-  query AllInvitations($limit: Int, $offset: Int,$orgToken: String!) {
-    getAllInvitations(limit: $limit, offset: $offset,orgToken: $orgToken) {
+  query AllInvitations($limit: Int, $offset: Int,$orgToken: String!,$sortBy:Int) {
+    getAllInvitations(limit: $limit, offset: $offset,orgToken: $orgToken,sortBy:$sortBy) {
       invitations {
         invitees {
           email
@@ -18,8 +18,8 @@ export const GET_ALL_INVITATIONS = gql`
 `;
 
 export const GET_INVITATIONS = gql`
-  query GetInvitations($query: String!, $limit: Int, $offset: Int,$orgToken: String!) {
-    getInvitations(query: $query, limit: $limit, offset: $offset,orgToken: $orgToken) {
+  query GetInvitations($query: String!, $limit: Int, $offset: Int,$orgToken: String!,$sortBy:Int) {
+    getInvitations(query: $query, limit: $limit, offset: $offset,orgToken: $orgToken,,sortBy:$sortBy) {
       invitations {
         invitees {
           email
@@ -33,8 +33,8 @@ export const GET_INVITATIONS = gql`
 `;
 
 export const GET_ROLES_AND_STATUSES = gql`
-  query filterInvitations($limit: Int, $offset: Int, $role: String, $status: String, $orgToken: String!) {
-    filterInvitations(limit: $limit, offset: $offset, role: $role, status: $status, orgToken: $orgToken) {
+  query filterInvitations($limit: Int, $offset: Int, $role: String, $status: String, $orgToken: String!,$sortBy:Int) {
+    filterInvitations(limit: $limit, offset: $offset, role: $role, status: $status, orgToken: $orgToken,sortBy:$sortBy) {
       invitations {
         invitees {
           email


### PR DESCRIPTION
## PR Description
This pull request implements sorting functionality for invitations, ensuring they can be ordered in both descending and ascending order based on the createdAt field. Additionally, the default behavior now ensures that the latest invitations are shown first.
## Description of tasks that were expected to be completed

- [x] Enable sorting in both descending and ascending order
- [x] Set the default sorting to descending 

## How has this been tested?

- Follow this link  https://metron-devpulse-git-ft-sort-invitations-metron.vercel.app
- Sign in as an admin with password: Test@12345 and email: [devpulse@proton.me](mailto:devpulse@proton.me)
- Navigate to invitations.
- Sort the invitation according to the latest or old one in the invitation table.

## Screenshots (If appropriate)
<img width="1440" alt="Screenshot 2024-10-17 at 14 12 35" src="https://github.com/user-attachments/assets/37fc26b6-0a0b-4f3b-82d4-8dea5494129d">

  
<img width="1440" alt="Screenshot 2024-10-17 at 14 12 53" src="https://github.com/user-attachments/assets/56eacfcc-2353-4f97-afa8-cacd8e128f90">
