### PR TITLE
#578 Improving search invitation to listern to typing event

### DIFF
--- a/src/components/InvitationTable.tsx
+++ b/src/components/InvitationTable.tsx
@@ -57,12 +57,6 @@ function DataTableStats({ data, columns, error, loading }: TableData) {
     setPageIndex(currentPageIndex);
   }, [currentPageIndex]);
 
-  useEffect(() => {
-    if (error) {
-      toast.error('Network error. Please, try again later.');
-    }
-  }, [error]);
-
   const handleFilterChange = (e) => {
     const value = e.target.value || '';
     setGlobalFilter(value);

--- a/src/pages/invitation.tsx
+++ b/src/pages/invitation.tsx
@@ -203,8 +203,7 @@ function Invitation() {
   ] = useLazyQuery(GET_INVITATIONS, {
     variables: {
      query: searchQuery,
-     orgToken: organizationToken,
-     sortBy:sortBy
+     orgToken: organizationToken
     },
     fetchPolicy: 'network-only',
   });
@@ -222,8 +221,7 @@ function Invitation() {
           variables: {
           role: filterVariables.role || null,
           status:filterVariables.status || null,
-          orgToken: organizationToken,
-          sortBy:sortBy
+          orgToken: organizationToken
         },
     });
     }
@@ -269,8 +267,10 @@ function Invitation() {
 
   const handleSearch = () => {
     if (!searchQuery.trim()) {
-      setError('Search query cannot be empty');
-      return;
+      if (data && data.getAllInvitations) {
+        setInvitations(data.getAllInvitations.invitations);
+        setTotalInvitations(data.getAllInvitations.totalInvitations);
+      }
     }
 
     setInvitations([]);
@@ -279,6 +279,14 @@ function Invitation() {
 
     fetchInvitations({ variables: { query: searchQuery } });
   };
+
+  useEffect(() => {
+    const delayDebounceFn = setTimeout(() => {
+      handleSearch();
+    }, 500);
+
+    return () => clearTimeout(delayDebounceFn);
+  }, [searchQuery]);
 
 
   useEffect(() => {
@@ -323,8 +331,6 @@ const handleStatusChange=(e:React.ChangeEvent<HTMLSelectElement>)=>{
   const toggleOptions = (row: string) => {
     setSelectedRow(selectedRow === row ? null : row);
   };
-
-  const disabledSearch = !searchQuery.trim();
 
   interface EmailInputProps {
     email: string;
@@ -820,21 +826,19 @@ setSortBy(sortBy)
           The “Search bar” below enables you to effortlessly check the status of
           sent invitations.
           <br />
-          Simply type in the email or name of the invitee in the search bar to
+          Simply type in the email, or role of the invitee or status of the invitation in the search bar to
           instantly retrieve real-time updates.
         </p>
 
         {/* Search form */}
         <div className='block lg:flex justify-between items-center'>
             <div className="flex flex-row md:flex-row gap-2 md:gap-2 md:w-[50%] w-full">
-              <div className="relative flex-1 text-black ">
+              <div className="relative flex-1 text-black">
                 <input
                   type="text"
                   id="search"
                   value={searchQuery}
-                  onChange={(e) => {
-                    setSearchQuery(e.target.value)
-                  }}
+                  onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search by email, role or status of the invitation."
                   className="border border-gray-300 outline-none bg-transparent rounded-md pl-10 pr-4 py-1 w-full dark:text-white hover:border-[#7258ce] dark:text:text-white sm:text-normal text-md dark:bg-[#04122F]"
                 />

--- a/src/queries/invitation.queries.tsx
+++ b/src/queries/invitation.queries.tsx
@@ -2,8 +2,8 @@ import { gql } from "@apollo/client";
 
 
 export const GET_ALL_INVITATIONS = gql`
-  query AllInvitations($limit: Int, $offset: Int,$orgToken: String!,$sortBy:Int) {
-    getAllInvitations(limit: $limit, offset: $offset,orgToken: $orgToken,sortBy:$sortBy) {
+  query AllInvitations($limit: Int, $offset: Int,$orgToken: String!) {
+    getAllInvitations(limit: $limit, offset: $offset,orgToken: $orgToken) {
       invitations {
         invitees {
           email
@@ -18,8 +18,8 @@ export const GET_ALL_INVITATIONS = gql`
 `;
 
 export const GET_INVITATIONS = gql`
-  query GetInvitations($query: String!, $limit: Int, $offset: Int,$orgToken: String!,$sortBy:Int) {
-    getInvitations(query: $query, limit: $limit, offset: $offset,orgToken: $orgToken,,sortBy:$sortBy) {
+  query GetInvitations($query: String!, $limit: Int, $offset: Int,$orgToken: String!) {
+    getInvitations(query: $query, limit: $limit, offset: $offset,orgToken: $orgToken) {
       invitations {
         invitees {
           email
@@ -33,8 +33,8 @@ export const GET_INVITATIONS = gql`
 `;
 
 export const GET_ROLES_AND_STATUSES = gql`
-  query filterInvitations($limit: Int, $offset: Int, $role: String, $status: String, $orgToken: String!,$sortBy:Int) {
-    filterInvitations(limit: $limit, offset: $offset, role: $role, status: $status, orgToken: $orgToken,sortBy:$sortBy) {
+  query filterInvitations($limit: Int, $offset: Int, $role: String, $status: String, $orgToken: String!) {
+    filterInvitations(limit: $limit, offset: $offset, role: $role, status: $status, orgToken: $orgToken) {
       invitations {
         invitees {
           email


### PR DESCRIPTION
# PR Description

Improving search invitation to listen to typing events and filter according to the typed value.

# Description of tasks that were expected to be completed

- Implemented a debounce mechanism to handle search input and avoid unnecessary API calls.
- Updated the handleSearch function to handle empty search queries properly.
- Ensured that the search functionality filters invitations based on the typed value.
- Refactored the code to handle errors without displaying toast notifications.

# How has this been tested?

clone [this](https://github.com/atlp-rwanda/atlp-pulse-fn) repostory  , cd into it 
run npm install to install deopendencies and npm run dev to start the server  or use this preview l[ink ](https://metron-devpulse-git-fx-search-invitations-metron.vercel.app/)

login in as damin with the following credentials 
emai : devpulse@proton.me
password: Test@12345

- Start the application and navigate to the invitation page.
- Type a search query in the search input field and observe the filtered results.
- Delete the search query and verify that the invitations are cleared and no errors are displayed.
- Simulate an error scenario and ensure that the error is handled without displaying a toast notification.

# Number of Commits

1

# Screenshots (If appropriate)

<img width="1440" alt="Screenshot 2024-10-18 at 13 23 31" src="https://github.com/user-attachments/assets/165c224b-cd9f-4384-aee8-c58d99af04ac">
<img width="1440" alt="Screenshot 2024-10-18 at 13 23 44" src="https://github.com/user-attachments/assets/1eb577c7-a11c-460c-988c-3f54333bfb27">

# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code generate no warnings
- [x] My test coverage meet the set test coverage threshold
- [x] There are no vulnerabilities
- [x] There are no conflicts with the base branch
