### PR TITLE
#595 Improve the dark mode skeleton to match the dark design

### DIFF
--- a/src/Skeletons/InvitationCardSkeleton.tsx
+++ b/src/Skeletons/InvitationCardSkeleton.tsx
@@ -4,17 +4,38 @@ import 'react-loading-skeleton/dist/skeleton.css';
 
 function InvitationCardSkeleton() {
   return (
-    <div className="bg-white rounded-md shadow-sm p-4 w-[100%] md:w-[30%]">
-      <div className="flex flex-row items-center gap-4 mb-3">
-        <Skeleton circle width={50} height={50} />
+    <div className='bg-white dark:bg-[#0A1729] rounded-md shadow-sm p-4 w-[100%] md:w-[30%]'>
+      <div className='flex flex-row items-center gap-4 mb-3'>
+        <Skeleton
+          circle
+          width={50}
+          height={50}
+          highlightColor='#E0E0E' 
+          className="dark:bg-[#4B5563]" 
+        />
         <div>
-          <Skeleton width={100} height={20} />
+          <Skeleton
+            width={100}
+            height={20}
+            highlightColor='#E0E0E' 
+            className="dark:bg-[#4B5563]" 
+          />
         </div>
       </div>
 
-      <Skeleton width={70} height={30} />
+      <Skeleton
+        width={70}
+        height={30}
+        highlightColor='#E0E0E' 
+        className="dark:bg-[#4B5563]" 
+      />
 
-      <Skeleton width={50} height={20} />
+      <Skeleton
+        width={50}
+        height={20}
+        highlightColor='#E0E0E' 
+        className="dark:bg-[#4B5563]" 
+      />
     </div>
   );
 }

--- a/src/Skeletons/SkeletonTable.tsx
+++ b/src/Skeletons/SkeletonTable.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 
 interface SkeletonTableProps {
@@ -11,18 +10,30 @@ function SkeletonTable({ columns }: SkeletonTableProps) {
       <thead>
         <tr>
           {columns.map((column: any, index: React.Key | null | undefined) => (
-            <th key={column.id || column.name} className="px-6 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
-              <div className="h-4 bg-gray-300 rounded w-3/4" aria-label="Loading skeleton" />
+            <th
+              key={column.id || column.name}
+              className="px-6 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider dark:bg-[#0A1729] dark:text-gray-400"
+            >
+              <div
+                className="h-4 bg-gray-300 rounded w-3/4 dark:bg-gray-700"
+                aria-label="Loading skeleton"
+              />
             </th>
           ))}
         </tr>
       </thead>
       <tbody>
-        {[...Array(5)].map((_, rowIndex:any) => (
+        {[...Array(5)].map((_, rowIndex: any) => (
           <tr key={rowIndex.id || rowIndex.name}>
-            {columns.map((_, colIndex:any) => (
-              <td key={colIndex.id || colIndex.name} className="px-6 py-4 border-b border-gray-200 bg-white text-sm">
-                <div className="h-4 bg-gray-300 rounded w-full" aria-label="Loading skeleton" />
+            {columns.map((_, colIndex: any) => (
+              <td
+                key={colIndex.id || colIndex.name}
+                className="px-6 py-4 border-b border-gray-200 bg-white text-sm dark:bg-[#0A1731] dark:border-gray-400"
+              >
+                <div
+                  className="h-4 bg-gray-300 rounded w-full dark:bg-gray-700"
+                  aria-label="Loading skeleton"
+                />
               </td>
             ))}
           </tr>


### PR DESCRIPTION
# PR Description

This PR improves the dark mode skeletons on the invitation page to better align with the overall dark design of the application.

# Description of tasks that were expected to be completed

- Changed the Skeleton colors  of cards and table match dark design.
- Ensured the Text box matches on both side.
- Ensure responsiveness are maintained


# How has this been tested?

Clone this repo, cd into it ,checkout the branch ft-improve-invitation-darkSkeleton then run :

npm install : to install dependences
npm run dev to start the server

or use this link: https://metron-devpulse-git-ft-improve-invitation-darkskeleton-metron.vercel.app/ 

log in with credential:
Email: [devpulse@proton.me](mailto:devpulse@proton.me)
password: Test@12345

# Number of Commits

1 Commit

# Screenshots (If appropriate)
Invitation Page: 
- Dark mode skeleton
![image](https://github.com/user-attachments/assets/14ec5773-eb1e-4a4c-9d90-c1b111854d76)
![image](https://github.com/user-attachments/assets/965cfe4a-81b2-47c0-91d8-e299356cfc37)



- Light mode skeleton
![image](https://github.com/user-attachments/assets/16ad2295-ecda-43cd-81d3-3eb079a28c1b)
![image](https://github.com/user-attachments/assets/f0bbd177-d389-4d7a-a845-654bb7442215)



# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code generate no warnings
- [x] My test coverage meet the set test coverage threshold
- [x] There are no vulnerabilities
- [x] There are no conflicts with the base branch
